### PR TITLE
🧹 cleanup benchmark imports

### DIFF
--- a/infra/scripts/benchmark.py
+++ b/infra/scripts/benchmark.py
@@ -10,9 +10,7 @@ import time
 import json
 import numpy as np
 import logging
-from pathlib import Path
 import sys
-import os
 from pathlib import Path
 
 # Fix PYTHONPATH


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removing an unused `import os` and a duplicate `from pathlib import Path` in `infra/scripts/benchmark.py`.

💡 **Why:** How this improves maintainability
Reducing dead code and redundancy makes the script cleaner, easier to read, and prevents linting warnings.

✅ **Verification:** How you confirmed the change is safe
- Verified that `os` is not used in the file using `grep`.
- Performed a syntax check using `python3 -m py_compile`.
- Retained one instance of `Path` which is required for the script.

✨ **Result:** The improvement achieved
A cleaner and more standard-compliant import block in the benchmark utility.

---
*PR created automatically by Jules for task [2021719578821436303](https://jules.google.com/task/2021719578821436303) started by @Moeabdelaziz007*