### PR TITLE
🔒 Remove hardcoded Google API key from debug script and documentation

### DIFF
--- a/aether_runtime_config.json.bak
+++ b/aether_runtime_config.json.bak
@@ -1,6 +1,6 @@
 {
-    "GOOGLE_API_KEY": "AIzaSyDYiZDepdqVUgkiZHVflEzO4aqu4JGVy3k",
-    "NEXT_PUBLIC_GEMINI_KEY": "AIzaSyDYiZDepdqVUgkiZHVflEzO4aqu4JGVy3k",
+    "GOOGLE_API_KEY": "YOUR_GOOGLE_API_KEY",
+    "NEXT_PUBLIC_GEMINI_KEY": "YOUR_GOOGLE_API_KEY",
     "AETHER_AI_MODEL": "gemini-2.5-flash-native-audio-preview-12-2025",
     "AETHER_AI_API_VERSION": "v1alpha",
     "AETHER_GW_PORT": 18789

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ gcloud run deploy aether-engine \
 For production security, move keys into GCP Secret Manager:
 
 ```bash
-echo -n "AIzaSy..." | gcloud secrets create GEMINI_KEY --data-file=-
+echo -n "YOUR_GOOGLE_API_KEY" | gcloud secrets create GEMINI_KEY --data-file=-
 gcloud run deploy aether-engine --update-secrets=GOOGLE_API_KEY=GEMINI_KEY:latest
 ```
 

--- a/infra/scripts/debug/test_key.py
+++ b/infra/scripts/debug/test_key.py
@@ -1,6 +1,24 @@
-import requests
+import os
 
-api_key = "AIzaSyDYiZDepdqVUgkiZHVflEzO4aqu4JGVy3k"
+try:
+    import requests
+except ImportError:
+    print("Error: 'requests' library not installed. Please install it with 'pip install requests'.")
+    exit(1)
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    # If dotenv is not installed, we continue and rely on environment variables being set manually
+    pass
+
+api_key = os.environ.get("GOOGLE_API_KEY")
+
+if not api_key:
+    print("Error: GOOGLE_API_KEY environment variable not set.")
+    exit(1)
+
 url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={api_key}"
 payload = {"contents": [{"parts": [{"text": "Hello"}]}]}
 response = requests.post(url, json=payload)


### PR DESCRIPTION
🎯 **What:** Removed a hardcoded Google API key from `infra/scripts/debug/test_key.py` and replaced it with a secure environment-variable-based approach. Also cleaned up occurrences of the same key in `aether_runtime_config.json.bak` and `docs/deployment.md`.

⚠️ **Risk:** Hardcoded API keys are easily exposed in source control, which can lead to unauthorized usage of the API, financial costs, and potential data breaches if the key has extensive permissions.

🛡️ **Solution:** The `test_key.py` script now uses `os.environ.get("GOOGLE_API_KEY")` and supports loading from a `.env` file via `python-dotenv`. Placeholders were used in documentation and backup configuration files to prevent future leaks while maintaining clarity for developers.

---
*PR created automatically by Jules for task [3997281362183496636](https://jules.google.com/task/3997281362183496636) started by @Moeabdelaziz007*