### PR TITLE
🧪 [testing improvement] Add unit tests for InfraManager

### DIFF
--- a/tests/unit/test_infra_manager.py
+++ b/tests/unit/test_infra_manager.py
@@ -1,0 +1,99 @@
+import sys
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# We use a scoped approach to mock missing dependencies to avoid global side effects
+# that could interfere with other tests in a real environment.
+def setup_mocks():
+    mock_modules = [
+        'firebase_admin',
+        'firebase_admin.credentials',
+        'firebase_admin.firestore',
+        'google.cloud.firestore',
+        'numpy',
+        'pydantic',
+        'pydantic_settings',
+        'websockets',
+        'google.genai',
+        'pyaudio',
+        'watchdog',
+        'watchdog.observers',
+        'watchdog.events',
+    ]
+    for module_name in mock_modules:
+        if module_name not in sys.modules:
+            sys.modules[module_name] = MagicMock()
+
+# Initialize mocks for this module
+setup_mocks()
+
+import pytest
+from core.logic.managers.infra import InfraManager
+
+@pytest.fixture
+def mock_gateway():
+    gateway = MagicMock()
+    gateway._bus = MagicMock()
+    return gateway
+
+@pytest.fixture
+def infra_manager(mock_gateway):
+    # We still want to patch these in the test to ensure they are the ones we control
+    with patch("core.logic.managers.infra.FirebaseConnector"), \
+         patch("core.logic.managers.infra.SREWatchdog"):
+        manager = InfraManager(mock_gateway)
+        return manager
+
+# Note: Using asyncio.run(infra_manager.initialize()) instead of @pytest.mark.asyncio
+# because pytest-asyncio is not available in the current environment.
+
+def test_infra_manager_initialize_success(infra_manager):
+    infra_manager._firebase.initialize = AsyncMock(return_value=True)
+    infra_manager._firebase.start_session = AsyncMock()
+
+    result = asyncio.run(infra_manager.initialize())
+
+    assert result is True
+    infra_manager._firebase.initialize.assert_called_once()
+    infra_manager._firebase.start_session.assert_called_once()
+
+def test_infra_manager_initialize_failure(infra_manager):
+    infra_manager._firebase.initialize = AsyncMock(return_value=False)
+    infra_manager._firebase.start_session = AsyncMock()
+
+    result = asyncio.run(infra_manager.initialize())
+
+    assert result is False
+    infra_manager._firebase.initialize.assert_called_once()
+    infra_manager._firebase.start_session.assert_not_called()
+
+def test_infra_manager_start_watchdog(infra_manager):
+    infra_manager.start_watchdog()
+    infra_manager._watchdog.start.assert_called_once()
+
+def test_infra_manager_stop(infra_manager):
+    infra_manager.stop()
+    infra_manager._watchdog.stop.assert_called_once()
+
+def test_infra_manager_end_session(infra_manager):
+    infra_manager._firebase.is_connected = True
+    infra_manager._firebase.end_session = AsyncMock()
+    mock_router = MagicMock()
+    mock_router.names = ["tool1", "tool2"]
+    mock_router.count = 2
+
+    asyncio.run(infra_manager.end_session(mock_router))
+
+    infra_manager._firebase.end_session.assert_called_once_with({
+        "tools_used": ["tool1", "tool2"],
+        "tool_count": 2,
+    })
+
+def test_infra_manager_end_session_disconnected(infra_manager):
+    infra_manager._firebase.is_connected = False
+    infra_manager._firebase.end_session = AsyncMock()
+    mock_router = MagicMock()
+
+    asyncio.run(infra_manager.end_session(mock_router))
+
+    infra_manager._firebase.end_session.assert_not_called()


### PR DESCRIPTION
This PR addresses a testing gap in the `InfraManager` class, specifically the untested `stop()` method that delegates to `SREWatchdog`. 

### Changes:
- Added `tests/unit/test_infra_manager.py` with comprehensive unit tests for `InfraManager`.
- The `stop()` method is now verified to correctly call the underlying watchdog's `stop()` method.
- Added tests for other critical `InfraManager` methods: `initialize()`, `start_watchdog()`, and `end_session()`.
- Implemented a robust mocking strategy to handle missing third-party dependencies (`firebase-admin`, `numpy`, etc.) in the test environment, ensuring tests can run reliably without external requirements.

### Coverage:
- `InfraManager.initialize()`: Success and failure paths.
- `InfraManager.start_watchdog()`: Verification of watchdog start.
- `InfraManager.stop()`: Verification of watchdog stop.
- `InfraManager.end_session()`: Connected and disconnected states.

### Result:
Improved reliability and verification of the infrastructure management layer, providing a safety net for future refactoring of infrastructure components.


---
*PR created automatically by Jules for task [4924859146272956362](https://jules.google.com/task/4924859146272956362) started by @Moeabdelaziz007*