### PR TITLE
🧪 [testing improvement] Add unit tests for InfraManager

### DIFF
--- a/tests/benchmarks/test_thalamic_gate_benchmark.py
+++ b/tests/benchmarks/test_thalamic_gate_benchmark.py
@@ -1,19 +1,19 @@
-
 import asyncio
 import time
-import numpy as np
-import pytest
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
+
 # Mock the audio_state singleton before it's imported by other modules
-from core.audio import state as audio_state_module
+
 mock_audio_state = MagicMock()
 mock_audio_state.far_end_pcm.read_last.return_value = np.zeros(512, dtype=np.int16)
-patcher = patch.dict('sys.modules', {'core.audio.state': mock_audio_state})
+patcher = patch.dict("sys.modules", {"core.audio.state": mock_audio_state})
 patcher.start()
 
-from core.audio.capture import AudioCapture
-from core.infra.config import AudioConfig
+from core.audio.capture import AudioCapture  # noqa: E402
+from core.infra.config import AudioConfig  # noqa: E402
 
 # Constants
 SAMPLE_RATE = 16000
@@ -22,28 +22,34 @@ CHUNK_SIZE = 512
 # Try to import the benchmark fixture, but don't fail if it's not there.
 try:
     from pytest_benchmark.fixture import BenchmarkFixture
+
     pytest_benchmark_installed = True
 except ImportError:
     pytest_benchmark_installed = False
-    BenchmarkFixture = object # Define a dummy for type hinting
+    BenchmarkFixture = object  # Define a dummy for type hinting
+
 
 @pytest.fixture
 def capture_instance():
     """Provides a fully mocked AudioCapture instance for benchmarking."""
     mock_config = AudioConfig(send_sample_rate=SAMPLE_RATE, chunk_size=CHUNK_SIZE)
     mock_queue = MagicMock(spec=asyncio.Queue)
-    
-    with (patch('core.audio.capture.DynamicAEC') as MockDynamicAEC,
-          patch('core.audio.capture.SmoothMuter'),
-          patch('core.audio.capture.HysteresisGate'),
-          patch('core.audio.capture.AECBridge'),
-          patch('core.audio.capture.energy_vad')):
 
+    with (
+        patch("core.audio.capture.DynamicAEC") as MockDynamicAEC,
+        patch("core.audio.capture.SmoothMuter"),
+        patch("core.audio.capture.HysteresisGate"),
+        patch("core.audio.capture.AECBridge"),
+        patch("core.audio.capture.energy_vad"),
+    ):
         mock_aec_instance = MockDynamicAEC.return_value
         mock_aec_state = MagicMock()
         mock_aec_state.converged = True
         mock_aec_state.convergence_progress = 1.0
-        mock_aec_instance.process_frame.return_value = (np.zeros(CHUNK_SIZE, dtype=np.int16), mock_aec_state)
+        mock_aec_instance.process_frame.return_value = (
+            np.zeros(CHUNK_SIZE, dtype=np.int16),
+            mock_aec_state,
+        )
 
         instance = AudioCapture(
             config=mock_config,
@@ -52,27 +58,29 @@ def capture_instance():
         instance._loop = MagicMock()
         return instance
 
+
 @pytest.fixture
 def callback_args():
     """Provides standard arguments for the _callback method."""
     in_data = (np.random.randn(CHUNK_SIZE) * 1000).astype(np.int16).tobytes()
-    return {
-        "in_data": in_data,
-        "frame_count": CHUNK_SIZE,
-        "time_info": {},
-        "status": 0
-    }
+    return {"in_data": in_data, "frame_count": CHUNK_SIZE, "time_info": {}, "status": 0}
 
-@pytest.mark.skipif(not pytest_benchmark_installed, reason="pytest-benchmark is not installed")
-def test_thalamic_gate_performance(benchmark: BenchmarkFixture, capture_instance, callback_args):
+
+@pytest.mark.skipif(
+    not pytest_benchmark_installed, reason="pytest-benchmark is not installed"
+)
+def test_thalamic_gate_performance(
+    benchmark: BenchmarkFixture, capture_instance, callback_args
+):
     """
     Benchmarks the execution time of the Thalamic Gate callback using pytest-benchmark.
     """
-    
+
     def run_callback():
         capture_instance._callback(**callback_args)
 
     benchmark(run_callback)
+
 
 def test_thalamic_gate_manual_benchmark(capture_instance, callback_args):
     """
@@ -80,22 +88,25 @@ def test_thalamic_gate_manual_benchmark(capture_instance, callback_args):
     This runs if pytest-benchmark is not available.
     """
     num_iterations = 1000
-    
+
     start_time = time.perf_counter()
     for _ in range(num_iterations):
         capture_instance._callback(**callback_args)
     end_time = time.perf_counter()
-    
+
     total_time = end_time - start_time
     avg_time_ms = (total_time / num_iterations) * 1000
-    
-    print(f"--- Manual Benchmark Results ---")
+
+    print("--- Manual Benchmark Results ---")
     print(f"Total iterations: {num_iterations}")
     print(f"Total time: {total_time:.4f} seconds")
     print(f"Average Thalamic Gate processing time: {avg_time_ms:.4f} ms per frame")
-    
+
     # The prompt claims ~1.5ms/frame performance, target is < 2ms
-    assert avg_time_ms < 2.5, f"Thalamic Gate is too slow ({avg_time_ms:.4f}ms), exceeds 2.5ms target."
+    assert avg_time_ms < 2.5, (
+        f"Thalamic Gate is too slow ({avg_time_ms:.4f}ms), exceeds 2.5ms target."
+    )
+
 
 # Stop the patcher after all tests are done
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/benchmarks/voice_quality_benchmark.py
+++ b/tests/benchmarks/voice_quality_benchmark.py
@@ -26,10 +26,8 @@ import logging
 import os
 import sys
 import time
-import wave
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 
@@ -39,12 +37,13 @@ sys.path.insert(0, str(ROOT))
 
 try:
     from dotenv import load_dotenv
+
     load_dotenv(ROOT / ".env")
 except ImportError:
     pass
 
-from google import genai
-from google.genai import types
+from google import genai  # noqa: E402
+from google.genai import types  # noqa: E402
 
 logger = logging.getLogger("voice_benchmark")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
@@ -53,9 +52,11 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message
 # Data Models
 # ═══════════════════════════════════════════════════════════
 
+
 @dataclass
 class BenchmarkResult:
     """Stores the results of a single benchmark run."""
+
     test_name: str
     metric: str
     value: float
@@ -68,6 +69,7 @@ class BenchmarkResult:
 @dataclass
 class VoiceBenchmarkReport:
     """Complete voice quality benchmark report."""
+
     results: list[BenchmarkResult] = field(default_factory=list)
     suggestions: list[str] = field(default_factory=list)
     timestamp: str = ""
@@ -96,14 +98,18 @@ class VoiceBenchmarkReport:
             status = "✅ PASS" if r.passed else "❌ FAIL"
             name = r.test_name[:28].ljust(28)
             val = f"{r.value:.1f}{r.unit}".ljust(9)
-            thr = f"<{r.threshold}{r.unit}".ljust(8) if r.threshold > 0 else "N/A".ljust(8)
+            thr = (
+                f"<{r.threshold}{r.unit}".ljust(8)
+                if r.threshold > 0
+                else "N/A".ljust(8)
+            )
             lines.append(f"│ {name} │ {val} │ {thr} │ {status} │")
 
         lines.append("└──────────────────────────────┴───────────┴──────────┴────────┘")
 
         passed = sum(1 for r in self.results if r.passed)
         total = len(self.results)
-        lines.append(f"\n  Score: {passed}/{total} ({passed/total*100:.0f}%)")
+        lines.append(f"\n  Score: {passed}/{total} ({passed / total * 100:.0f}%)")
 
         if self.suggestions:
             lines.append("\n  ════ Voice Quality Improvement Suggestions ════")
@@ -118,21 +124,24 @@ class VoiceBenchmarkReport:
 # Benchmark Tests
 # ═══════════════════════════════════════════════════════════
 
-def generate_test_tone(freq_hz: float = 440.0, duration_s: float = 1.0,
-                        sample_rate: int = 16000) -> bytes:
+
+def generate_test_tone(
+    freq_hz: float = 440.0, duration_s: float = 1.0, sample_rate: int = 16000
+) -> bytes:
     """Generate a pure sine wave tone as PCM16 bytes."""
     t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
     samples = (np.sin(2 * np.pi * freq_hz * t) * 16000).astype(np.int16)
     return samples.tobytes()
 
 
-def generate_speech_like_signal(duration_s: float = 2.0,
-                                 sample_rate: int = 16000) -> bytes:
+def generate_speech_like_signal(
+    duration_s: float = 2.0, sample_rate: int = 16000
+) -> bytes:
     """Generate a speech-like signal with formants for testing."""
     t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
     # Simulate speech with multiple formants
-    f1 = np.sin(2 * np.pi * 150 * t) * 8000   # Fundamental (male voice)
-    f2 = np.sin(2 * np.pi * 500 * t) * 4000   # First formant
+    f1 = np.sin(2 * np.pi * 150 * t) * 8000  # Fundamental (male voice)
+    f2 = np.sin(2 * np.pi * 500 * t) * 4000  # First formant
     f3 = np.sin(2 * np.pi * 1500 * t) * 2000  # Second formant
     f4 = np.sin(2 * np.pi * 2500 * t) * 1000  # Third formant
 
@@ -176,21 +185,21 @@ async def benchmark_round_trip_latency(
             async with client.aio.live.connect(model=model, config=config) as session:
                 start = time.perf_counter()
                 await session.send_client_content(
-                    turns=[types.Content(parts=[types.Part(text=f"Ping #{i+1}")])]
+                    turns=[types.Content(parts=[types.Part(text=f"Ping #{i + 1}")])]
                 )
                 async for response in session.receive():
                     if response.data:
                         latency_ms = (time.perf_counter() - start) * 1000
                         latencies.append(latency_ms)
-                        logger.info(f"  Iteration {i+1}: {latency_ms:.0f}ms")
+                        logger.info(f"  Iteration {i + 1}: {latency_ms:.0f}ms")
                         break
                     if response.text:
                         latency_ms = (time.perf_counter() - start) * 1000
                         latencies.append(latency_ms)
-                        logger.info(f"  Iteration {i+1}: {latency_ms:.0f}ms (text)")
+                        logger.info(f"  Iteration {i + 1}: {latency_ms:.0f}ms (text)")
                         break
         except Exception as e:
-            logger.warning(f"  Iteration {i+1} failed: {e}")
+            logger.warning(f"  Iteration {i + 1} failed: {e}")
             latencies.append(5000.0)
 
     avg = sum(latencies) / len(latencies) if latencies else 9999.0
@@ -259,7 +268,7 @@ Respond in this exact JSON format:
                 temperature=0.3,
             ),
         )
-        
+
         result_text = response.text.strip()
         # Parse JSON response
         data = json.loads(result_text)
@@ -267,15 +276,18 @@ Respond in this exact JSON format:
         suggestions = data.get("suggestions", [])
         assessment = data.get("overall_assessment", "No assessment")
 
-        return BenchmarkResult(
-            test_name="AI Voice Quality Score",
-            metric="quality_score",
-            value=score,
-            unit="/100",
-            passed=score >= 70,
-            threshold=70,
-            details=assessment,
-        ), suggestions
+        return (
+            BenchmarkResult(
+                test_name="AI Voice Quality Score",
+                metric="quality_score",
+                value=score,
+                unit="/100",
+                passed=score >= 70,
+                threshold=70,
+                details=assessment,
+            ),
+            suggestions,
+        )
 
     except Exception as e:
         logger.error(f"Voice quality analysis failed: {e}")
@@ -322,7 +334,9 @@ def benchmark_aec_effectiveness() -> BenchmarkResult:
     noise = (np.random.randn(len(t)) * 200).astype(np.int16)
 
     mic_full = np.zeros_like(far_end_full)
-    mic_full[delay_samples:] = (far_end_full[:-delay_samples] * echo_gain).astype(np.int16)
+    mic_full[delay_samples:] = (far_end_full[:-delay_samples] * echo_gain).astype(
+        np.int16
+    )
     mic_full += noise
 
     erle_values = []
@@ -336,7 +350,7 @@ def benchmark_aec_effectiveness() -> BenchmarkResult:
         erle_values.append(state.erle_db)
 
     # Average ERLE over last 60% of frames (after convergence)
-    converged_erle = erle_values[int(len(erle_values) * 0.4):]
+    converged_erle = erle_values[int(len(erle_values) * 0.4) :]
     avg_erle = np.mean(converged_erle) if converged_erle else 0.0
 
     return BenchmarkResult(
@@ -360,7 +374,6 @@ def benchmark_vad_accuracy() -> BenchmarkResult:
     from core.audio.processing import AdaptiveVAD, energy_vad
 
     vad = AdaptiveVAD()
-    sample_rate = 16000
     correct = 0
     total = 0
 
@@ -418,8 +431,12 @@ def benchmark_thalamic_gate_latency() -> BenchmarkResult:
     )
 
     # Pre-generate test frames
-    mic_frames = [(np.random.randn(frame_size) * 5000).astype(np.int16) for _ in range(100)]
-    ref_frames = [(np.random.randn(frame_size) * 3000).astype(np.int16) for _ in range(100)]
+    mic_frames = [
+        (np.random.randn(frame_size) * 5000).astype(np.int16) for _ in range(100)
+    ]
+    ref_frames = [
+        (np.random.randn(frame_size) * 3000).astype(np.int16) for _ in range(100)
+    ]
 
     # Warmup
     for i in range(10):
@@ -451,6 +468,7 @@ def benchmark_thalamic_gate_latency() -> BenchmarkResult:
 # Main Runner
 # ═══════════════════════════════════════════════════════════
 
+
 async def run_all_benchmarks() -> VoiceBenchmarkReport:
     """Execute the full voice quality benchmark suite."""
     api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
@@ -475,7 +493,11 @@ async def run_all_benchmarks() -> VoiceBenchmarkReport:
         report.add(result)
     except Exception as e:
         logger.error(f"Latency benchmark failed: {e}")
-        report.add(BenchmarkResult("Round-Trip Latency", "latency_ms", 9999, "ms", False, 500, str(e)))
+        report.add(
+            BenchmarkResult(
+                "Round-Trip Latency", "latency_ms", 9999, "ms", False, 500, str(e)
+            )
+        )
 
     # 2. Voice Quality Analysis & Suggestions
     try:
@@ -500,7 +522,9 @@ async def run_all_benchmarks() -> VoiceBenchmarkReport:
         report.add(result)
     except Exception as e:
         logger.error(f"VAD benchmark failed: {e}")
-        report.add(BenchmarkResult("VAD Accuracy", "accuracy_%", 0, "%", False, 85, str(e)))
+        report.add(
+            BenchmarkResult("VAD Accuracy", "accuracy_%", 0, "%", False, 85, str(e))
+        )
 
     # 5. Thalamic Gate Latency
     try:
@@ -508,7 +532,9 @@ async def run_all_benchmarks() -> VoiceBenchmarkReport:
         report.add(result)
     except Exception as e:
         logger.error(f"Gate latency benchmark failed: {e}")
-        report.add(BenchmarkResult("Gate Latency", "gate_ms", 999, "ms", False, 2, str(e)))
+        report.add(
+            BenchmarkResult("Gate Latency", "gate_ms", 999, "ms", False, 2, str(e))
+        )
 
     report.total_duration_s = time.perf_counter() - start_time
 

--- a/tests/e2e/test_e2e_singularity.py
+++ b/tests/e2e/test_e2e_singularity.py
@@ -11,7 +11,7 @@ lifecycle of the Aether Live Agent, proving cohesion between:
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -44,13 +44,16 @@ async def test_e2e_singularity():
 
     # Initialize Real Firebase for Collective Memory
     from core.infra.cloud.firebase.interface import FirebaseConnector
+
     fb_connector = FirebaseConnector()
     connected = await fb_connector.initialize()
     if not connected:
-        print("[WARNING] Real Firebase connector could not initialize. Ensure credentials are set.")
-    
+        print(
+            "[WARNING] Real Firebase connector could not initialize. Ensure credentials are set."
+        )
+
     await fb_connector.start_session()
-    
+
     hive_memory.set_firebase_connector(fb_connector)
 
     # Register core modules into router
@@ -78,9 +81,9 @@ async def test_e2e_singularity():
     vad_res = energy_vad(speech_signal, adaptive_engine=vad)
     assert vad_res.is_hard, f"Failed to detect speech. RMS: {vad_res.energy_rms}"
 
-    assert (
-        hive.active_soul.manifest.name == "ArchitectExpert"
-    ), "Default must be Architect."
+    assert hive.active_soul.manifest.name == "ArchitectExpert", (
+        "Default must be Architect."
+    )
     print(f"[E2E] Speech detected. Active Soul: {hive.active_soul.manifest.name}")
 
     # Simulate Gemini executing parallel write_memory calls
@@ -103,10 +106,10 @@ async def test_e2e_singularity():
 
     assert results[0].get("x-a2a-status") == 200, f"Write failed: {results[0]}"
     assert results[1].get("x-a2a-status") == 200
-    
+
     # Wait briefly for cloud sync
     await asyncio.sleep(1.0)
-    
+
     print("[E2E] Parallel Memory Write OK.")
 
     # ==========================================
@@ -114,7 +117,9 @@ async def test_e2e_singularity():
     # ==========================================
     # System evaluates a new user intent "Can you write the code now?"
     print("[E2E] Evaluating intent shift to Coding...")
-    target_expert = await hive.evaluate_intent("Write the python code for the system plan.")
+    target_expert = await hive.evaluate_intent(
+        "Write the python code for the system plan."
+    )
     assert target_expert == "CodingExpert"
 
     # Architect calls handoff tool
@@ -127,9 +132,9 @@ async def test_e2e_singularity():
 
     handoff_result = await router.dispatch(mock_fc_handoff)
 
-    assert (
-        handoff_result["result"].get("status") == "handoff_initiated"
-    ), f"Handoff failed: {handoff_result}"
+    assert handoff_result["result"].get("status") == "handoff_initiated", (
+        f"Handoff failed: {handoff_result}"
+    )
     assert restart_event.is_set(), "Session restart signal must be fired."
     print("[E2E] Autonomous Handoff OK.")
 

--- a/tests/e2e/test_performance_stress.py
+++ b/tests/e2e/test_performance_stress.py
@@ -7,16 +7,19 @@ Benchmarks latency for handshake, audio ingestion, and telemetry overhead.
 import asyncio
 import json
 import time
+from pathlib import Path
+
+import nacl.signing
 import pytest
 import websockets
-import nacl.signing
-from pathlib import Path
+
+from core.ai.hive import HiveCoordinator
 
 # Aether Core Imports
 from core.infra.transport.gateway import AetherGateway
-from core.ai.hive import HiveCoordinator
-from core.tools.router import ToolRouter
 from core.services.registry import AetherRegistry
+from core.tools.router import ToolRouter
+
 
 class PerfGatewayConfig:
     def __init__(self, port=18996):
@@ -27,9 +30,11 @@ class PerfGatewayConfig:
         self.handshake_timeout_s = 2.0
         self.receive_sample_rate = 16000
 
+
 class PerfAIConfig:
     def __init__(self):
-        from tests.e2e.test_system_alpha_e2e import E2EModel, E2EAudioConfig
+        from tests.e2e.test_system_alpha_e2e import E2EAudioConfig, E2EModel
+
         self.audio = E2EAudioConfig()
         self.api_key = "dummy"
         self.api_version = "v1beta"
@@ -41,79 +46,93 @@ class PerfAIConfig:
         self.proactive_audio = False
         self.debug = False
 
+
 @pytest.mark.asyncio
 async def test_handshake_latency():
     print("\n[PERF] Benchmarking Handshake Latency...")
-    
+
     # Setup
     signing_key = nacl.signing.SigningKey.generate()
     client_id = signing_key.verify_key.encode().hex().lower()
-    
+
     reg_path = Path("/tmp/aether_perf_registry")
     if reg_path.exists():
         import shutil
+
         shutil.rmtree(reg_path)
     reg_path.mkdir(parents=True)
     (reg_path / client_id).mkdir()
     with open(reg_path / client_id / "manifest.json", "w") as f:
-        json.dump({
-            "name": client_id,
-            "version": "1.0.0",
-            "persona": "Perf Probe",
-            "public_key": client_id
-        }, f)
-        
+        json.dump(
+            {
+                "name": client_id,
+                "version": "1.0.0",
+                "persona": "Perf Probe",
+                "public_key": client_id,
+            },
+            f,
+        )
+
     registry = AetherRegistry(packages_dir=str(reg_path))
     registry.scan()
     from tests.e2e.test_system_alpha_e2e import E2EAudioConfig
+
     gateway = AetherGateway(
         gateway_config=PerfGatewayConfig(),
         audio_config=E2EAudioConfig(),
         ai_config=PerfAIConfig(),
         tool_router=ToolRouter(),
-        hive=HiveCoordinator(registry=registry, router=ToolRouter())
+        hive=HiveCoordinator(registry=registry, router=ToolRouter()),
     )
-    
+
     # Mock GlobalBus to avoid Redis timeout
     from unittest.mock import AsyncMock
+
     gateway._bus.connect = AsyncMock(return_value=True)
-    
+
     gw_task = asyncio.create_task(gateway.run())
     await asyncio.sleep(0.5)
-    
+
     latencies = []
-    
+
     for i in range(5):
         start_time = time.perf_counter()
-        async with websockets.connect(f"ws://127.0.0.1:18996") as ws:
+        async with websockets.connect("ws://127.0.0.1:18996") as ws:
             # 1. Challenge
             msg = json.loads(await ws.recv())
             # 2. Response
             token_bytes = bytes.fromhex(msg["challenge"])
             sig = signing_key.sign(token_bytes).signature.hex()
-            await ws.send(json.dumps({
-                "type": "connect.response",
-                "client_id": client_id,
-                "signature": sig
-            }))
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "connect.response",
+                        "client_id": client_id,
+                        "signature": sig,
+                    }
+                )
+            )
             # 3. ACK
             ack = json.loads(await ws.recv())
             end_time = time.perf_counter()
-            
+
             latency_ms = (end_time - start_time) * 1000
             latencies.append(latency_ms)
-            print(f"[PERF] Iteration {i+1}: {latency_ms:.2f}ms")
+            print(f"[PERF] Iteration {i + 1}: {latency_ms:.2f}ms")
             assert ack["type"] == "connect.ack"
 
     avg_latency = sum(latencies) / len(latencies)
     print(f"[PERF] Average Handshake Latency: {avg_latency:.2f}ms")
-    
+
     # Target: < 200ms for local handshake
     assert avg_latency < 200
-    
+
     gw_task.cancel()
-    try: await gw_task
-    except asyncio.CancelledError: pass
+    try:
+        await gw_task
+    except asyncio.CancelledError:
+        pass
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])

--- a/tests/e2e/test_singularity_gauntlet.py
+++ b/tests/e2e/test_singularity_gauntlet.py
@@ -10,10 +10,10 @@ Validates:
 
 import asyncio
 import os
-from google.genai import types
 
 import numpy as np
 import pytest
+from google.genai import types
 
 from core.ai import handoff
 from core.audio.processing import AdaptiveVAD
@@ -32,10 +32,7 @@ async def test_parallel_tool_stress():
 
     router.register("slow_tool", "A slow tool", {"x": {"type": "integer"}}, slow_tool)
 
-    calls = [
-        types.FunctionCall(name="slow_tool", args={"x": i}) 
-        for i in range(10)
-    ]
+    calls = [types.FunctionCall(name="slow_tool", args={"x": i}) for i in range(10)]
 
     # Dispatch in parallel (simulating session._handle_tool_call logic)
     tasks = [router.dispatch(c) for c in calls]
@@ -51,11 +48,11 @@ async def test_parallel_tool_stress():
 async def test_semantic_recovery_success():
     """Phase 7.3: Verify Neural Dispatcher V3 recovers typos via semantic search."""
     router = ToolRouter()
-    
+
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
         pytest.skip("GEMINI_API_KEY required for real semantic recovery test")
-        
+
     router.init_vector_store(api_key=api_key)
 
     # Register the real tool
@@ -66,8 +63,8 @@ async def test_semantic_recovery_success():
 
     # Genuine Google GenAI FunctionCall
     mock_fc = types.FunctionCall(
-        name="delegate_to_agnt", 
-        args={"target_agent_id": "test", "task_description": "test"}
+        name="delegate_to_agnt",
+        args={"target_agent_id": "test", "task_description": "test"},
     )
 
     result = await router.dispatch(mock_fc)

--- a/tests/e2e/test_system_alpha_e2e.py
+++ b/tests/e2e/test_system_alpha_e2e.py
@@ -6,23 +6,25 @@ Hardened E2E test with strict timeouts and granular logging to debug protocol ha
 
 import asyncio
 import json
-import base64
 import os
+from pathlib import Path
+
+import nacl.encoding
+import nacl.signing
 import pytest
 import websockets
-import nacl.signing
-import nacl.encoding
-from pathlib import Path
+
+from core.ai.hive import HiveCoordinator
 
 # Aether Core Imports
 from core.infra.transport.gateway import AetherGateway
-from core.ai.hive import HiveCoordinator
-from core.tools.router import ToolRouter
 from core.services.registry import AetherRegistry
+from core.tools.router import ToolRouter
+
 
 # Configuration for Test Environment
 class E2EGatewayConfig:
-    def __init__(self, port=18995): # Different port to avoid conflict
+    def __init__(self, port=18995):  # Different port to avoid conflict
         self.port = port
         self.host = "127.0.0.1"
         self.tick_interval_s = 1.0
@@ -30,13 +32,16 @@ class E2EGatewayConfig:
         self.handshake_timeout_s = 3.0
         self.receive_sample_rate = 16000
 
+
 class E2EAudioConfig:
     def __init__(self):
         self.mic_queue_max = 5
 
+
 class E2EModel:
     def __init__(self, value):
         self.value = value
+
 
 class E2EAIConfig:
     def __init__(self):
@@ -51,37 +56,42 @@ class E2EAIConfig:
         self.proactive_audio = False
         self.debug = True
 
+
 @pytest.mark.asyncio
 async def test_aether_system_alpha_full_cycle():
     print("\n[PROBE] Starting Diagnostic E2E Cycle...")
-    
+
     # 1. SETUP REGISTRY & KEYS
     signing_key = nacl.signing.SigningKey.generate()
     public_key_hex = signing_key.verify_key.encode().hex().lower()
     client_id = public_key_hex
-    
+
     registry_path = Path("/tmp/aether_diagnostic_registry")
     if registry_path.exists():
         import shutil
+
         shutil.rmtree(registry_path)
     registry_path.mkdir(parents=True)
-    
+
     # Create Soul Manifest
     arch_path = registry_path / client_id
     arch_path.mkdir()
     with open(arch_path / "manifest.json", "w") as f:
-        json.dump({
-            "name": client_id,
-            "version": "1.0.0",
-            "persona": "Diagnostic Soul",
-            "public_key": public_key_hex,
-            "expertise": {"diagnostics": 1.0}
-        }, f)
+        json.dump(
+            {
+                "name": client_id,
+                "version": "1.0.0",
+                "persona": "Diagnostic Soul",
+                "public_key": public_key_hex,
+                "expertise": {"diagnostics": 1.0},
+            },
+            f,
+        )
 
     registry = AetherRegistry(packages_dir=str(registry_path))
     registry.scan()
     print(f"[PROBE] Registry initialized with {registry.count} souls.")
-    
+
     hive = HiveCoordinator(registry=registry, router=ToolRouter())
     gw_cfg = E2EGatewayConfig()
     gateway = AetherGateway(
@@ -89,67 +99,70 @@ async def test_aether_system_alpha_full_cycle():
         audio_config=E2EAudioConfig(),
         ai_config=E2EAIConfig(),
         tool_router=ToolRouter(),
-        hive=hive
+        hive=hive,
     )
-    
+
     # Start Backend
     # Mock GlobalBus to avoid Redis timeout
     from unittest.mock import AsyncMock
+
     gateway._bus.connect = AsyncMock(return_value=True)
-    
+
     print("[PROBE] Starting Gateway Server...")
     gw_task = asyncio.create_task(gateway.run())
-    await asyncio.sleep(1.0) # Ensure server is up
-    
+    await asyncio.sleep(1.0)  # Ensure server is up
+
     try:
         uri = f"ws://{gw_cfg.host}:{gw_cfg.port}"
         print(f"[PROBE] Connecting to {uri}...")
-        
-        async with asyncio.timeout(10.0): # Global test timeout
+
+        async with asyncio.timeout(10.0):  # Global test timeout
             async with websockets.connect(uri) as ws:
                 print("[PROBE] WebSocket Connected. Awaiting Challenge...")
-                
+
                 # Receive Challenge
                 raw_challenge = await asyncio.wait_for(ws.recv(), timeout=3.0)
                 challenge_msg = json.loads(raw_challenge)
                 print(f"[PROBE] Received Challenge: {challenge_msg['type']}")
                 assert challenge_msg["type"] == "connect.challenge"
-                
+
                 # Sign Challenge
                 # CRITICAL: gateway verifies against raw bytes, so we sign the bytes from the hex token
                 token_hex = challenge_msg["challenge"]
                 token_bytes = bytes.fromhex(token_hex)
                 sig_obj = signing_key.sign(token_bytes)
                 sig_hex = sig_obj.signature.hex()
-                
+
                 # Send Response
                 resp = {
                     "type": "connect.response",
                     "client_id": client_id,
                     "signature": sig_hex,
-                    "capabilities": ["voice.stream"]
+                    "capabilities": ["voice.stream"],
                 }
                 print("[PROBE] Sending Handshake Response...")
                 await ws.send(json.dumps(resp))
-                
+
                 # Receive ACK or Error
                 print("[PROBE] Awaiting ACK/Result...")
                 raw_ack = await asyncio.wait_for(ws.recv(), timeout=5.0)
                 ack_msg = json.loads(raw_ack)
                 print(f"[PROBE] Result Received: {ack_msg['type']}")
-                
+
                 if ack_msg["type"] == "error":
-                    print(f"[PROBE] Protocol Error (Expected if AI Auth fails): {ack_msg.get('message')}")
-                    return # Passthrough success for protocol validation
-                
+                    print(
+                        f"[PROBE] Protocol Error (Expected if AI Auth fails): {ack_msg.get('message')}"
+                    )
+                    return  # Passthrough success for protocol validation
+
                 assert ack_msg["type"] == "connect.ack"
                 print(f"[PROBE] Session Established: {ack_msg['session_id']}")
-                
+
                 # Send Dummy Audio (3200 bytes = 100ms pcm16)
                 print("[PROBE] Sending Small Audio Burst...")
-                await ws.send(bytes([0]*3200))
+                await ws.send(bytes([0] * 3200))
                 print("[PROBE] Audio Sent. Verifying Hive status...")
-                
+
                 assert hive.active_soul is not None
                 print(f"[PROBE] Active Soul: {hive.active_soul.manifest.name}")
 
@@ -167,6 +180,7 @@ async def test_aether_system_alpha_full_cycle():
         except asyncio.CancelledError:
             pass
         print("[PROBE] Diagnostic Cycle Complete.")
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s", "-vv"])

--- a/tests/e2e/test_telemetry_flow.py
+++ b/tests/e2e/test_telemetry_flow.py
@@ -5,33 +5,34 @@ Verifies that TelemetryManager correctly dispatches spans via OTLP.
 """
 
 import asyncio
-import json
-import pytest
 import os
-from pathlib import Path
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 # Aether Core Imports
 from core.infra.telemetry import TelemetryManager
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
 
 @pytest.mark.asyncio
 async def test_telemetry_span_dispatch():
     print("\n[PROBE] Starting Telemetry Flow Test...")
-    
+
     # 1. SETUP TELEMETRY (In-Memory for Verification)
     memory_exporter = InMemorySpanExporter()
-    original_service_name = os.environ.get("OTEL_SERVICE_NAME", "aether-test")
-    
+    os.environ.get("OTEL_SERVICE_NAME", "aether-test")
+
     # Initialize with local memory exporter
     tm = TelemetryManager(model_id="aether-e2e-probe")
     tm.initialize()
-    
+
     # Inject memory exporter for test verification
     from opentelemetry import trace as trace_api_global
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
     provider = trace_api_global.get_tracer_provider()
     provider.add_span_processor(SimpleSpanProcessor(memory_exporter))
-    
+
     print("[PROBE] Creating Test Spans...")
     with tm.tracer.start_as_current_span("e2e.handshake") as span:
         span.set_attribute("client_id", "perf-probe-123")
@@ -42,25 +43,27 @@ async def test_telemetry_span_dispatch():
     with tm.tracer.start_as_current_span("e2e.audio_stream") as span:
         span.set_attribute("bytes_received", 32000)
         from opentelemetry.trace import Status, StatusCode
+
         span.set_status(Status(StatusCode.ERROR, "audio_buffer_overflow"))
         span.set_attribute("buffer_id", "rx-01")
-    
+
     # Force flush using global provider
     trace_api_global.get_tracer_provider().force_flush()
-    
+
     # 2. VERIFY
     spans = memory_exporter.get_finished_spans()
     print(f"[PROBE] Captured {len(spans)} spans in memory.")
-    
+
     span_names = [s.name for s in spans]
     assert "e2e.handshake" in span_names
     assert "e2e.audio_stream" in span_names
-    
+
     # Check attributes
     handshake_span = next(s for s in spans if s.name == "e2e.handshake")
     assert handshake_span.attributes["client_id"] == "perf-probe-123"
-    
+
     print("[PROBE] Telemetry Dispatch Verified.")
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])

--- a/tests/integration/test_gateway_e2e.py
+++ b/tests/integration/test_gateway_e2e.py
@@ -5,22 +5,25 @@ Tests the actual Ed25519 handshake and WebSocket lifecycle without mocks.
 """
 
 import asyncio
-import json
 import base64
+import json
+import os
+
+import nacl.encoding
+import nacl.signing
 import pytest
 import websockets
-import nacl.signing
-import nacl.encoding
-import os
-from typing import Any
+
 
 # Standardizing configuration to match what AetherGateway and AI Session expect
 class MockAudioConfig:
     mic_queue_max = 5
 
+
 class MockModel:
     def __init__(self, value):
         self.value = value
+
 
 class UnifiedMockAIConfig:
     def __init__(self):
@@ -35,6 +38,7 @@ class UnifiedMockAIConfig:
         self.proactive_audio = False
         self.debug = False
 
+
 class MockGatewayConfig:
     def __init__(self, port):
         self.port = port
@@ -44,11 +48,13 @@ class MockGatewayConfig:
         self.handshake_timeout_s = 10.0
         self.receive_sample_rate = 16000
 
+
 class MockManifest:
     def __init__(self, name):
         self.name = name
         self.persona = "You are the Aether Architect Expert."
         self.expertise = ["Cloud Architecture", "AI Systems"]
+
 
 class MockSoul:
     def __init__(self, name):
@@ -56,40 +62,42 @@ class MockSoul:
         self.persona = self.manifest.persona
         self.expertise = self.manifest.expertise
 
+
 @pytest.mark.asyncio
 async def test_gateway_handshake_e2e():
     # 1. Setup Gateway Backend
-    from core.infra.transport.gateway import AetherGateway
-    from core.tools.router import ToolRouter
     from core.ai.hive import HiveCoordinator
+    from core.infra.transport.gateway import AetherGateway
     from core.services.registry import AetherRegistry
-    
+    from core.tools.router import ToolRouter
+
     gw_cfg = MockGatewayConfig(port=18840)
     ai_cfg = UnifiedMockAIConfig()
-    
+
     # Ensure environment is clean
     os.environ["GOOGLE_API_KEY"] = "dummy"
 
     # Instantiate dependencies
     registry = AetherRegistry(packages_dir="/tmp")
     tool_router = ToolRouter()
-    
+
     # Inject active soul manually
     hive = HiveCoordinator(registry=registry, router=tool_router)
     hive._active_soul = MockSoul("ArchitectExpert")
-    
+
     gateway = AetherGateway(
         gateway_config=gw_cfg,
         ai_config=ai_cfg,
         audio_config=MockAudioConfig(),
         tool_router=tool_router,
-        hive=hive
+        hive=hive,
     )
-    
+
     # Mock GlobalBus to avoid Redis timeout
     from unittest.mock import AsyncMock
+
     gateway._bus.connect = AsyncMock(return_value=True)
-    
+
     # Start gateway in the background
     gw_task = asyncio.create_task(gateway.run())
     await asyncio.sleep(1)  # Wait for bind
@@ -98,7 +106,7 @@ async def test_gateway_handshake_e2e():
         # 2. Setup Client (Prober)
         signing_key = nacl.signing.SigningKey.generate()
         verify_key = signing_key.verify_key
-        client_id = base64.b64encode(verify_key.encode()).decode('utf-8')
+        client_id = base64.b64encode(verify_key.encode()).decode("utf-8")
 
         uri = f"ws://localhost:{gw_cfg.port}"
         async with websockets.connect(uri) as websocket:
@@ -111,36 +119,40 @@ async def test_gateway_handshake_e2e():
             # 4. Sign Challenge & Respond
             challenge_bytes = challenge_token.encode()
             signature = signing_key.sign(challenge_bytes)
-            
+
             client_response = {
                 "type": "connect.response",
                 "client_id": client_id,
-                "signature": base64.b64encode(signature.signature).decode('utf-8'),
-                "capabilities": ["voice.stream"]
+                "signature": base64.b64encode(signature.signature).decode("utf-8"),
+                "capabilities": ["voice.stream"],
             }
             await websocket.send(json.dumps(client_response))
 
             # 5. Receive Handshake Response (ACK or Error)
             raw_response = await websocket.recv()
             resp_msg = json.loads(raw_response)
-            
+
             # Note: We are testing the GATEWAY'S secure handshake.
             # Even if the subsequent Gemini connection fails (due to dummy key),
             # the Gateway should have already verified our Ed25519 signature
             # and potentially sent an ACK or is about to send an error from AI failure.
-            
+
             if resp_msg["type"] == "error":
                 # If it's an AI error, the handshake *itself* might have passed
                 # logic check if it reached the AI connection stage.
                 if "API key not valid" in resp_msg.get("message", ""):
-                    print("\n✅ Handshake Verified (Ed25519 passed, but AI key is dummy).")
+                    print(
+                        "\n✅ Handshake Verified (Ed25519 passed, but AI key is dummy)."
+                    )
                     return
-                pytest.fail(f"Handshake failed with unexpected error: {resp_msg.get('message')}")
-            
+                pytest.fail(
+                    f"Handshake failed with unexpected error: {resp_msg.get('message')}"
+                )
+
             assert resp_msg["type"] == "connect.ack"
             assert "session_id" in resp_msg
-            
-            print(f"\n✅ Neural Link Probe Successful. Handshake Verified.")
+
+            print("\n✅ Neural Link Probe Successful. Handshake Verified.")
 
     finally:
         gw_task.cancel()
@@ -148,6 +160,7 @@ async def test_gateway_handshake_e2e():
             await gw_task
         except asyncio.CancelledError:
             pass
+
 
 if __name__ == "__main__":
     asyncio.run(test_gateway_handshake_e2e())

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -2,12 +2,14 @@
 Aether Voice OS — Neural Summarizer Unit Tests.
 """
 
-import asyncio
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
 from core.ai.compression import NeuralSummarizer
-from core.ai.handover_protocol import HandoverContext, ConversationEntry, WorkingMemory
+from core.ai.handover_protocol import ConversationEntry, HandoverContext
 from core.infra.config import AIConfig
+
 
 @pytest.fixture
 def mock_config():
@@ -15,49 +17,51 @@ def mock_config():
     config.api_key = "test_key"
     return config
 
+
 @pytest.mark.asyncio
 async def test_summarizer_should_compress():
     summarizer = NeuralSummarizer(MagicMock())
-    
+
     # Small context should not trigger compression
     small_context = HandoverContext(
         handover_id="test-1",
         source_agent="A",
         target_agent="B",
         task="Test small",
-        conversation_history=[]
+        conversation_history=[],
     )
     assert summarizer.should_compress(small_context) is False
-    
+
     # Large context should trigger compression
-    large_history = [
-        ConversationEntry(speaker="User", message="Hello" * 100)
-    ] * 25
+    large_history = [ConversationEntry(speaker="User", message="Hello" * 100)] * 25
     large_context = HandoverContext(
         handover_id="test-2",
         source_agent="A",
         target_agent="B",
         task="Test large",
-        conversation_history=large_history
+        conversation_history=large_history,
     )
     assert summarizer.should_compress(large_context) is True
+
 
 @pytest.mark.asyncio
 async def test_summarizer_compress_fallback(mock_config):
     # Test that it handles errors gracefully
     summarizer = NeuralSummarizer(mock_config)
-    
+
     # Mock the client to raise an exception
-    summarizer._client.models.generate_content = MagicMock(side_effect=Exception("API Error"))
-    
+    summarizer._client.models.generate_content = MagicMock(
+        side_effect=Exception("API Error")
+    )
+
     context = HandoverContext(
         handover_id="test-3",
         source_agent="A",
         target_agent="B",
         task="Test fallback",
-        conversation_history=[ConversationEntry(speaker="User", message="Test")]
+        conversation_history=[ConversationEntry(speaker="User", message="Test")],
     )
-    
+
     seed = await summarizer.compress(context)
     assert "error" in seed
     assert seed["fallback_summary"] == "Test fallback"

--- a/tests/test_firebase_backend.py
+++ b/tests/test_firebase_backend.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import unittest
-from unittest.mock import patch, MagicMock
 
 from core.infra.cloud.firebase import FirebaseConnector
 

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,8 +1,8 @@
 import logging
 
-from core.ai.handover.manager import MultiAgentOrchestrator
 from core.ai.agents.specialists.architect import ArchitectAgent
 from core.ai.agents.specialists.debugger import DebuggerAgent
+from core.ai.handover.manager import MultiAgentOrchestrator
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,9 +3,16 @@ Aether Voice OS — Session State Persistence Real Integration Tests.
 """
 
 import asyncio
+
 import pytest
+
 from core.infra.transport.bus import GlobalBus
-from core.infra.transport.session_state import SessionStateManager, SessionMetadata, SessionState
+from core.infra.transport.session_state import (
+    SessionMetadata,
+    SessionState,
+    SessionStateManager,
+)
+
 
 @pytest.mark.asyncio
 async def test_persistence_real_redis():
@@ -13,27 +20,29 @@ async def test_persistence_real_redis():
     bus = GlobalBus(prefix="aether_test_persist:")
     if not await bus.connect():
         pytest.skip("Redis not available")
-        
+
     try:
         # Instance A: Save
         manager_a = SessionStateManager(bus=bus)
         session_id = f"test-real-{asyncio.get_event_loop().time()}"
         metadata = SessionMetadata(session_id=session_id, soul_name="AetherReal")
-        
-        await manager_a.transition_to(SessionState.CONNECTED, reason="Real Persistence Test", metadata=metadata)
+
+        await manager_a.transition_to(
+            SessionState.CONNECTED, reason="Real Persistence Test", metadata=metadata
+        )
         manager_a.increment_message_count()
-        
+
         # Wait for background persistence (increment_message_count uses a task)
         await asyncio.sleep(0.2)
-        
+
         # Instance B: Restore
         manager_b = SessionStateManager(bus=bus)
         success = await manager_b.restore_from_bus(session_id)
-        
+
         assert success is True
         assert manager_b.metadata.session_id == session_id
         assert manager_b.metadata.message_count == 1
         assert manager_b.metadata.soul_name == "AetherReal"
-        
+
     finally:
         await bus.disconnect()

--- a/tests/test_telemetry_cost.py
+++ b/tests/test_telemetry_cost.py
@@ -3,42 +3,44 @@ Aether Voice OS — Cost Telemetry Verification.
 """
 
 import logging
-import pytest
+
 from core.infra.telemetry import record_usage
+
 
 def test_cost_recording_logic(caplog):
     """Verify that record_usage calculates and logs cost correctly."""
     caplog.set_level(logging.INFO)
-    
+
     # Simulate a session with 1M prompt tokens and 1M completion tokens
     # Prices for gemini-2.0-flash: input=$0.10/1M, output=$0.40/1M
     # Expected cost = 0.10 + 0.40 = $0.50
-    
+
     record_usage(
         session_id="cost-test-123",
         prompt_tokens=1_000_000,
         completion_tokens=1_000_000,
-        model="gemini-2.0-flash"
+        model="gemini-2.0-flash",
     )
-    
+
     # Check logs
     assert "Estimated Cost=$0.500000" in caplog.text
     assert "Session cost-test-123" in caplog.text
     assert "Prompt=1000000" in caplog.text
     assert "Completion=1000000" in caplog.text
 
+
 def test_cost_recording_pro_model(caplog):
     """Verify that cost calculation adjusts for different models (Gemini 2.0 Pro)."""
     caplog.clear()
     caplog.set_level(logging.INFO)
-    
+
     # gemini-2.0-pro: input=$1.25/1M, output=$5.00/1M
     # prompt=1M, completion=1M -> cost=$6.25
     record_usage(
         session_id="cost-test-pro",
         prompt_tokens=1_000_000,
         completion_tokens=1_000_000,
-        model="gemini-2.0-pro"
+        model="gemini-2.0-pro",
     )
-    
+
     assert "Estimated Cost=$6.250000" in caplog.text

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -4,9 +4,12 @@ Aether Voice OS — SRE Watchdog Real Integration Tests.
 
 import asyncio
 import logging
+
 import pytest
+
 from core.infra.transport.bus import GlobalBus
 from core.services.watchdog import SREWatchdog
+
 
 @pytest.mark.asyncio
 async def test_watchdog_real_healing():
@@ -14,10 +17,10 @@ async def test_watchdog_real_healing():
     bus = GlobalBus(prefix="aether_test_watchdog:")
     if not await bus.connect():
         pytest.skip("Redis not available")
-        
+
     try:
         heal_event = asyncio.Event()
-        
+
         async def real_heal_action():
             heal_event.set()
 
@@ -25,17 +28,17 @@ async def test_watchdog_real_healing():
         # Register real action for pattern
         watchdog._healing_registry["CRITICAL_ERROR"] = real_heal_action
         watchdog.start()
-        
+
         # Trigger real log event
         test_logger = logging.getLogger("AetherCoreEngine")
         test_logger.propagate = False
         test_logger.addHandler(watchdog._log_handler)
-        
+
         test_logger.error("SYSTEM CRITICAL_ERROR DETECTED")
-        
+
         await asyncio.wait_for(heal_event.wait(), timeout=3.0)
         assert heal_event.is_set(), "Healing action failed to trigger on real event"
-        
+
     finally:
         watchdog.stop()
         await bus.disconnect()

--- a/tests/unit/test_bus_sync.py
+++ b/tests/unit/test_bus_sync.py
@@ -2,10 +2,13 @@
 Aether Voice OS — Global State Bus Real Integration Tests.
 """
 
-import pytest
 import asyncio
+
+import pytest
+
 from core.infra.transport.bus import GlobalBus
-from core.infra.transport.session_state import SessionStateManager, SessionState
+from core.infra.transport.session_state import SessionState, SessionStateManager
+
 
 @pytest.mark.asyncio
 async def test_bus_publish_subscribe_real():
@@ -13,54 +16,55 @@ async def test_bus_publish_subscribe_real():
     bus = GlobalBus()
     if not await bus.connect():
         pytest.skip("Redis not available for real tests")
-        
+
     try:
         callback_called = asyncio.Event()
         received_data = None
-        
+
         async def test_callback(data):
             nonlocal received_data
             received_data = data
             callback_called.set()
-            
+
         await bus.subscribe("real_test_channel", test_callback)
-        
+
         # Small sleep to ensure subscription is active in Redis
         await asyncio.sleep(0.1)
-        
+
         test_payload = {"hello": "real_world", "timestamp": "now"}
         await bus.publish("real_test_channel", test_payload)
-        
+
         await asyncio.wait_for(callback_called.wait(), timeout=2.0)
         assert received_data == test_payload
-        
+
     finally:
         await bus.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_session_state_global_sync_real():
     """Verify that SessionStateManager correctly syncs state across instances via real Redis."""
     bus_a = GlobalBus(prefix="aether_test:")
     bus_b = GlobalBus(prefix="aether_test:")
-    
+
     if not await bus_a.connect() or not await bus_b.connect():
         pytest.skip("Redis not available")
-        
+
     try:
         manager_a = SessionStateManager(bus=bus_a)
         manager_b = SessionStateManager(bus=bus_b)
-        
+
         # Wait for subscriptions to settle
         await asyncio.sleep(0.2)
-        
+
         # Transition A -> Updates B?
         await manager_a.transition_to(SessionState.CONNECTED, reason="Sync Test")
-        
+
         # Wait for propagation
         reached = await manager_b.wait_for_state([SessionState.CONNECTED], timeout=2.0)
         assert reached is True
         assert manager_b.state == SessionState.CONNECTED
-        
+
     finally:
         await bus_a.disconnect()
         await bus_b.disconnect()

--- a/tests/unit/test_capture_callback.py
+++ b/tests/unit/test_capture_callback.py
@@ -24,24 +24,31 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-
 # Patch the audio_state module before importing AudioCapture
 mock_audio_state = MagicMock()
 mock_audio_state.far_end_pcm.read_last.return_value = np.zeros(512, dtype=np.int16)
 mock_audio_state.capture_queue_drops = 0
 
-patcher = patch.dict("sys.modules", {"core.audio.state": MagicMock(audio_state=mock_audio_state, HysteresisGate=MagicMock())})
+patcher = patch.dict(
+    "sys.modules",
+    {
+        "core.audio.state": MagicMock(
+            audio_state=mock_audio_state, HysteresisGate=MagicMock()
+        )
+    },
+)
 patcher.start()
 
 from core.audio.capture import AudioCapture, SmoothMuter  # noqa: E402
 from core.infra.config import AudioConfig  # noqa: E402
 
-
 SAMPLE_RATE = 16000
 CHUNK_SIZE = 512
 
 
-def _sine_pcm16(freq_hz: float, amp: float, n: int = CHUNK_SIZE, sr: int = SAMPLE_RATE) -> np.ndarray:
+def _sine_pcm16(
+    freq_hz: float, amp: float, n: int = CHUNK_SIZE, sr: int = SAMPLE_RATE
+) -> np.ndarray:
     t = np.arange(n, dtype=np.float64) / sr
     x = amp * np.sin(2.0 * np.pi * freq_hz * t)
     return (np.clip(x, -1.0, 1.0) * 32767.0).astype(np.int16)
@@ -68,7 +75,7 @@ def test_smooth_muter_ramp_is_gradual_and_hits_target():
     assert np.all(y2[-10:] == 0)
 
     muter.unmute()
-    y3 = muter.process(x)
+    muter.process(x)
     # After unmute, gain should have risen (ramp_samples=256 fits inside chunk of 512)
     assert muter._current_gain == 1.0
 
@@ -98,7 +105,9 @@ def capture_instance():
     mock_audio_state.is_playing = False
     mock_audio_state.just_started_playing = False
     mock_audio_state.just_stopped_playing = False
-    mock_audio_state.far_end_pcm.read_last.return_value = np.zeros(CHUNK_SIZE, dtype=np.int16)
+    mock_audio_state.far_end_pcm.read_last.return_value = np.zeros(
+        CHUNK_SIZE, dtype=np.int16
+    )
     mock_audio_state.capture_queue_drops = 0
 
     config = AudioConfig(send_sample_rate=SAMPLE_RATE, chunk_size=CHUNK_SIZE)
@@ -152,7 +161,9 @@ def test_callback_runs_when_ai_playing(capture_instance: AudioCapture):
     assert status is not None
 
 
-def test_push_to_async_queue_overflow_drops_oldest_and_counts_telemetry(capture_instance: AudioCapture):
+def test_push_to_async_queue_overflow_drops_oldest_and_counts_telemetry(
+    capture_instance: AudioCapture,
+):
     # Simulate QueueFull once, then success.
     q = capture_instance._async_queue
 

--- a/tests/unit/test_cybernetic_core.py
+++ b/tests/unit/test_cybernetic_core.py
@@ -6,8 +6,8 @@ import numpy as np
 from core.audio.playback import AudioPlayback
 from core.audio.processing import SilenceType, SilentAnalyzer
 from core.audio.state import audio_state
-from core.tools.voice_auth import VoiceAuthGuard
 from core.infra.config import AudioConfig
+from core.tools.voice_auth import VoiceAuthGuard
 
 
 class TestCyberneticCore(unittest.TestCase):

--- a/tests/unit/test_dynamic_aec.py
+++ b/tests/unit/test_dynamic_aec.py
@@ -19,24 +19,27 @@ import pytest
 
 from core.audio.dynamic_aec import DynamicAEC, FrequencyDomainNLMS
 
-
 SAMPLE_RATE = 16000
 FRAME_SIZE = 256
 ECHO_DELAY_MS = 50
 
 
-def _sine_pcm16(freq_hz: float, duration_s: float, amp: float, sr: int = SAMPLE_RATE) -> np.ndarray:
+def _sine_pcm16(
+    freq_hz: float, duration_s: float, amp: float, sr: int = SAMPLE_RATE
+) -> np.ndarray:
     t = np.arange(int(duration_s * sr), dtype=np.float64) / sr
     x = amp * np.sin(2.0 * np.pi * freq_hz * t)
     return (np.clip(x, -1.0, 1.0) * 32767.0).astype(np.int16)
 
 
-def _delayed_attenuated_echo(x: np.ndarray, delay_samples: int, gain: float) -> np.ndarray:
+def _delayed_attenuated_echo(
+    x: np.ndarray, delay_samples: int, gain: float
+) -> np.ndarray:
     y = np.zeros_like(x)
     if delay_samples < len(x):
-        y[delay_samples:] = (x[: len(x) - delay_samples].astype(np.float64) * gain).astype(
-            np.int16
-        )
+        y[delay_samples:] = (
+            x[: len(x) - delay_samples].astype(np.float64) * gain
+        ).astype(np.int16)
     return y
 
 
@@ -70,7 +73,11 @@ def test_erle_exceeds_12db_with_synthetic_echo(aec: DynamicAEC):
 
     rng = np.random.default_rng(0)
     noise = (rng.standard_normal(len(far)) * 0.01 * 32767.0).astype(np.int16)
-    near = (echo.astype(np.int32) + noise.astype(np.int32)).clip(-32768, 32767).astype(np.int16)
+    near = (
+        (echo.astype(np.int32) + noise.astype(np.int32))
+        .clip(-32768, 32767)
+        .astype(np.int16)
+    )
 
     states = _run_aec(aec, near=near, far=far)
     assert states, "No frames processed"
@@ -120,7 +127,9 @@ def test_double_talk_detection_triggers_during_overlap(aec: DynamicAEC):
 
     detected = any(
         st.double_talk_detected
-        for st in states[overlap_start_frame: max(overlap_start_frame + 1, overlap_end_frame)]
+        for st in states[
+            overlap_start_frame : max(overlap_start_frame + 1, overlap_end_frame)
+        ]
     )
     assert detected, "Double-talk was not detected during user-overlap"
 
@@ -173,4 +182,6 @@ def test_nlms_effective_step_size_mu_decreases_with_higher_input_power():
     nlms.process(far_high, near)
     mu_high = nlms.step_size / (nlms.power_estimate + nlms.regularization)
 
-    assert float(np.mean(mu_high)) < float(np.mean(mu_low)), "mu did not decrease with power"
+    assert float(np.mean(mu_high)) < float(np.mean(mu_low)), (
+        "mu did not decrease with power"
+    )

--- a/tests/unit/test_gateway.py
+++ b/tests/unit/test_gateway.py
@@ -1,24 +1,28 @@
 import asyncio
 import json
+from unittest.mock import MagicMock
 
 import pytest
 import websockets
 
-from unittest.mock import MagicMock
+from core.infra.config import AIConfig, AudioConfig, GatewayConfig
 from core.infra.transport.gateway import AetherGateway
 from core.infra.transport.messages import MessageType
-from core.infra.config import GatewayConfig, AIConfig, AudioConfig
 
 
 class SoulManifestStub:
     def __init__(self, name="AetherArchitect", voice_id="Puck"):
         from dataclasses import dataclass
+
         @dataclass
         class Manifest:
             name: str
             voice_id: str
             expertise: dict = None
-        self.manifest = Manifest(name=name, voice_id=voice_id, expertise={"sysadmin": 1.0})
+
+        self.manifest = Manifest(
+            name=name, voice_id=voice_id, expertise={"sysadmin": 1.0}
+        )
         self.persona = "Stub persona"
         self.name = name
 
@@ -38,36 +42,31 @@ def gateway_config():
 async def gateway(gateway_config):
     ai_config = AIConfig(GOOGLE_API_KEY="test", _env_file=None)
     audio_config = AudioConfig()
-    
+
     # Tool Router with concrete count
     tool_router = MagicMock()
     tool_router.count = 0
     tool_router.names = []
-    
+
     # Soul with concrete attributes instead of MagicMocks
     active_soul_obj = SoulManifestStub()
-    
+
     hive = MagicMock()
     hive.active_soul = active_soul_obj
     hive.get_active_soul.return_value = active_soul_obj
     hive.get_pending_handover_for_target.return_value = None
-    
+
     # Also fix Signature verification so it passes with dummy 0*128 signature
     import core.utils.security as sec
+
     sec.verify_signature = MagicMock(return_value=True)
-    
-    gw = AetherGateway(
-        gateway_config,
-        ai_config,
-        audio_config,
-        tool_router,
-        hive
-    )
-    
-    # Mock the GlobalBus so it doesn't try to connect to a missing Redis server 
+
+    gw = AetherGateway(gateway_config, ai_config, audio_config, tool_router, hive)
+
+    # Mock the GlobalBus so it doesn't try to connect to a missing Redis server
     # and time out for 5 seconds, which would fail the server start.
     gw._bus.connect = MagicMock(return_value=asyncio.sleep(0, result=True))
-    
+
     task = asyncio.create_task(gw.run())
     # Give the server a moment to start
     await asyncio.sleep(0.1)

--- a/tests/unit/test_gemini_live_session.py
+++ b/tests/unit/test_gemini_live_session.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/unit/test_infra_manager.py
+++ b/tests/unit/test_infra_manager.py
@@ -1,34 +1,38 @@
-import sys
 import asyncio
-from unittest.mock import MagicMock, AsyncMock, patch
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
 
 # We use a scoped approach to mock missing dependencies to avoid global side effects
 # that could interfere with other tests in a real environment.
 def setup_mocks():
     mock_modules = [
-        'firebase_admin',
-        'firebase_admin.credentials',
-        'firebase_admin.firestore',
-        'google.cloud.firestore',
-        'numpy',
-        'pydantic',
-        'pydantic_settings',
-        'websockets',
-        'google.genai',
-        'pyaudio',
-        'watchdog',
-        'watchdog.observers',
-        'watchdog.events',
+        "firebase_admin",
+        "firebase_admin.credentials",
+        "firebase_admin.firestore",
+        "google.cloud.firestore",
+        "numpy",
+        "pydantic",
+        "pydantic_settings",
+        "websockets",
+        "google.genai",
+        "pyaudio",
+        "watchdog",
+        "watchdog.observers",
+        "watchdog.events",
     ]
     for module_name in mock_modules:
         if module_name not in sys.modules:
             sys.modules[module_name] = MagicMock()
 
+
 # Initialize mocks for this module
 setup_mocks()
 
-import pytest
-from core.logic.managers.infra import InfraManager
+import pytest  # noqa: E402
+
+from core.logic.managers.infra import InfraManager  # noqa: E402
+
 
 @pytest.fixture
 def mock_gateway():
@@ -36,16 +40,21 @@ def mock_gateway():
     gateway._bus = MagicMock()
     return gateway
 
+
 @pytest.fixture
 def infra_manager(mock_gateway):
     # We still want to patch these in the test to ensure they are the ones we control
-    with patch("core.logic.managers.infra.FirebaseConnector"), \
-         patch("core.logic.managers.infra.SREWatchdog"):
+    with (
+        patch("core.logic.managers.infra.FirebaseConnector"),
+        patch("core.logic.managers.infra.SREWatchdog"),
+    ):
         manager = InfraManager(mock_gateway)
         return manager
 
+
 # Note: Using asyncio.run(infra_manager.initialize()) instead of @pytest.mark.asyncio
 # because pytest-asyncio is not available in the current environment.
+
 
 def test_infra_manager_initialize_success(infra_manager):
     infra_manager._firebase.initialize = AsyncMock(return_value=True)
@@ -57,6 +66,7 @@ def test_infra_manager_initialize_success(infra_manager):
     infra_manager._firebase.initialize.assert_called_once()
     infra_manager._firebase.start_session.assert_called_once()
 
+
 def test_infra_manager_initialize_failure(infra_manager):
     infra_manager._firebase.initialize = AsyncMock(return_value=False)
     infra_manager._firebase.start_session = AsyncMock()
@@ -67,13 +77,16 @@ def test_infra_manager_initialize_failure(infra_manager):
     infra_manager._firebase.initialize.assert_called_once()
     infra_manager._firebase.start_session.assert_not_called()
 
+
 def test_infra_manager_start_watchdog(infra_manager):
     infra_manager.start_watchdog()
     infra_manager._watchdog.start.assert_called_once()
 
+
 def test_infra_manager_stop(infra_manager):
     infra_manager.stop()
     infra_manager._watchdog.stop.assert_called_once()
+
 
 def test_infra_manager_end_session(infra_manager):
     infra_manager._firebase.is_connected = True
@@ -84,10 +97,10 @@ def test_infra_manager_end_session(infra_manager):
 
     asyncio.run(infra_manager.end_session(mock_router))
 
-    infra_manager._firebase.end_session.assert_called_once_with({
-        "tools_used": ["tool1", "tool2"],
-        "tool_count": 2,
-    })
+    infra_manager._firebase.end_session.assert_called_once_with(
+        {"tools_used": ["tool1", "tool2"], "tool_count": 2}
+    )
+
 
 def test_infra_manager_end_session_disconnected(infra_manager):
     infra_manager._firebase.is_connected = False

--- a/tests/unit/test_paralinguistics.py
+++ b/tests/unit/test_paralinguistics.py
@@ -13,15 +13,15 @@ externally where needed.
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from core.audio.paralinguistics import ParalinguisticAnalyzer
-
 
 SAMPLE_RATE = 16000
 
 
-def _sine_pcm16(freq_hz: float, duration_s: float, amp: float, sr: int = SAMPLE_RATE) -> np.ndarray:
+def _sine_pcm16(
+    freq_hz: float, duration_s: float, amp: float, sr: int = SAMPLE_RATE
+) -> np.ndarray:
     n = int(duration_s * sr)
     t = np.arange(n, dtype=np.float64) / sr
     x = amp * np.sin(2.0 * np.pi * freq_hz * t)

--- a/tests/unit/test_smooth_muter.py
+++ b/tests/unit/test_smooth_muter.py
@@ -1,44 +1,48 @@
-
 import numpy as np
 import pytest
+
 from core.audio.capture import SmoothMuter
 
 # Constants
 RAMP_SAMPLES = 256
-CHUNK_SIZE = 128 # Smaller than ramp for multi-chunk testing
+CHUNK_SIZE = 128  # Smaller than ramp for multi-chunk testing
 SAMPLE_RATE = 16000
+
 
 @pytest.fixture
 def muter():
     """Provides a SmoothMuter instance with a fixed ramp time."""
     return SmoothMuter(ramp_samples=RAMP_SAMPLES)
 
+
 def generate_dc_signal(level: float, num_samples: int) -> np.ndarray:
     """Generates a DC signal (constant value) to make testing ramps easy."""
     return (np.full(num_samples, level) * 32767).astype(np.int16)
+
 
 def test_muter_initial_state(muter):
     """Tests that the muter starts in an unmuted (pass-through) state."""
     signal = generate_dc_signal(0.5, CHUNK_SIZE)
     processed_signal = muter.process(signal)
-    
+
     assert muter._current_gain == 1.0
     assert muter._target_gain == 1.0
     np.testing.assert_array_equal(signal, processed_signal)
+
 
 def test_muter_mute_ramp(muter):
     """
     Tests the fade-out (mute) ramp over several chunks.
     """
     signal = generate_dc_signal(1.0, CHUNK_SIZE)
-    
+
     # Initial state is 1.0
     assert muter._current_gain == 1.0
-    
+
     # Initiate mute
     muter.mute()
     assert muter._target_gain == 0.0
-    
+
     # --- Process first chunk ---
     chunk1 = muter.process(signal.copy())
     # Gain should have decreased
@@ -46,12 +50,12 @@ def test_muter_mute_ramp(muter):
     assert muter._current_gain > 0.0
     # The output signal should be attenuated, check the last sample
     assert np.abs(chunk1[-1]) < np.abs(signal[-1])
-    
+
     # --- Process second chunk ---
-    chunk2 = muter.process(signal.copy())
+    muter.process(signal.copy())
     # RAMP_SAMPLES (256) is CHUNK_SIZE (128) * 2, so it should be at zero now.
     assert muter._current_gain == 0.0
-    
+
     # --- Process third chunk (should be silent) ---
     chunk3 = muter.process(signal.copy())
     # The output should be all zeros
@@ -62,20 +66,21 @@ def test_muter_mute_ramp(muter):
     assert muter._current_gain == 0.0
     np.testing.assert_array_equal(chunk3, np.zeros(CHUNK_SIZE, dtype=np.int16))
 
+
 def test_muter_unmute_ramp(muter):
     """
     Tests the fade-in (unmute) ramp.
     """
     signal = generate_dc_signal(1.0, CHUNK_SIZE)
-    
+
     # Start in a muted state
     muter._current_gain = 0.0
     muter._target_gain = 0.0
-    
+
     # Initiate unmute
     muter.unmute()
     assert muter._target_gain == 1.0
-    
+
     # --- Process first chunk ---
     chunk1 = muter.process(signal.copy())
     assert muter._current_gain > 0.0
@@ -84,7 +89,7 @@ def test_muter_unmute_ramp(muter):
     assert np.max(np.abs(chunk1)) < np.max(np.abs(signal))
 
     # --- Process second chunk ---
-    chunk2 = muter.process(signal.copy())
+    muter.process(signal.copy())
     # Should be at full gain now
     assert muter._current_gain == 1.0
 
@@ -92,6 +97,7 @@ def test_muter_unmute_ramp(muter):
     chunk3 = muter.process(signal.copy())
     assert muter._current_gain == 1.0
     np.testing.assert_array_equal(chunk3, signal)
+
 
 def test_smoothness_of_ramp_to_prevent_clicks():
     """
@@ -113,14 +119,16 @@ def test_smoothness_of_ramp_to_prevent_clicks():
     # The maximum change should be very small relative to the signal's max value
     max_diff = np.max(np.abs(diffs))
     max_signal_val = np.max(np.abs(signal))
-    
+
     # A click would be a significant fraction of the signal's amplitude.
     # The ramped change should be much smaller. The theoretical max change for
     # a DC signal is max_val / ramp_samples.
     expected_max_diff = max_signal_val / muter._ramp_samples
-    
+
     print(f"Max sample-to-sample diff: {max_diff:.2f}")
     print(f"Expected max diff: {expected_max_diff:.2f}")
 
     # Allow a small tolerance
-    assert max_diff < expected_max_diff * 1.5, "Ramp is not smooth, potential for clicks"
+    assert max_diff < expected_max_diff * 1.5, (
+        "Ramp is not smooth, potential for clicks"
+    )

--- a/tests/unit/test_spectral.py
+++ b/tests/unit/test_spectral.py
@@ -15,11 +15,12 @@ import numpy as np
 
 from core.audio.spectral import SpectralAnalyzer, erle, gcc_phat
 
-
 SAMPLE_RATE = 16000
 
 
-def _sine(freq_hz: float, n: int, amp: float = 0.8, sr: int = SAMPLE_RATE) -> np.ndarray:
+def _sine(
+    freq_hz: float, n: int, amp: float = 0.8, sr: int = SAMPLE_RATE
+) -> np.ndarray:
     t = np.arange(n, dtype=np.float64) / sr
     return amp * np.sin(2.0 * np.pi * freq_hz * t)
 

--- a/tests/unit/test_vad.py
+++ b/tests/unit/test_vad.py
@@ -14,17 +14,23 @@ on semantic outcomes rather than exact numerical equality.
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
-from core.audio.processing import AdaptiveVAD, HyperVADResult, SilentAnalyzer, SilenceType, energy_vad
-
+from core.audio.processing import (
+    AdaptiveVAD,
+    HyperVADResult,
+    SilenceType,
+    SilentAnalyzer,
+    energy_vad,
+)
 
 SAMPLE_RATE = 16000
 CHUNK_DURATION_S = 0.1
 CHUNK_SAMPLES = int(SAMPLE_RATE * CHUNK_DURATION_S)
 
 
-def _sine_pcm16(freq_hz: float, amp: float, n: int = CHUNK_SAMPLES, sr: int = SAMPLE_RATE) -> np.ndarray:
+def _sine_pcm16(
+    freq_hz: float, amp: float, n: int = CHUNK_SAMPLES, sr: int = SAMPLE_RATE
+) -> np.ndarray:
     t = np.arange(n, dtype=np.float64) / sr
     x = amp * np.sin(2.0 * np.pi * freq_hz * t)
     return (np.clip(x, -1.0, 1.0) * 32767.0).astype(np.int16)

--- a/tests/unit/test_voice_tool.py
+++ b/tests/unit/test_voice_tool.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from core.tools.voice_tool import VoiceState, VoiceTool
 from core.infra.config import AetherConfig, AIConfig, AudioConfig, GatewayConfig
+from core.tools.voice_tool import VoiceState, VoiceTool
 
 # ── Fixtures ────────────────────────────────────────────────
 
@@ -192,18 +192,12 @@ class TestEngineRegistration:
         from core.engine import AetherEngine
 
         engine = AetherEngine(config=mock_config)
-        tool1 = VoiceTool()
+        VoiceTool()
         engine._router.register(
-            name="voice",
-            description="test",
-            parameters={},
-            handler=MagicMock()
+            name="voice", description="test", parameters={}, handler=MagicMock()
         )
         engine._router.register(
-            name="search",
-            description="test",
-            parameters={},
-            handler=MagicMock()
+            name="search", description="test", parameters={}, handler=MagicMock()
         )
         assert engine._router.count >= 2
 

--- a/tests/verify_persistence.py
+++ b/tests/verify_persistence.py
@@ -4,14 +4,18 @@ Aether Voice OS — Persistence Verification.
 
 import asyncio
 import logging
-from datetime import datetime
-from unittest.mock import MagicMock
+
 from core.infra.transport.bus import GlobalBus
-from core.infra.transport.session_state import SessionStateManager, SessionMetadata, SessionState
+from core.infra.transport.session_state import (
+    SessionMetadata,
+    SessionState,
+    SessionStateManager,
+)
+
 
 async def verify_persistence():
     logging.basicConfig(level=logging.INFO)
-    
+
     # 1. Setup Bus
     bus = GlobalBus()
     if not await bus.connect():
@@ -21,9 +25,11 @@ async def verify_persistence():
     # 2. Instance A: Create and transition session
     manager_a = SessionStateManager(bus=bus)
     metadata = SessionMetadata(session_id="verify-sid-123", soul_name="Aether")
-    await manager_a.transition_to(SessionState.CONNECTED, reason="Unit Test", metadata=metadata)
+    await manager_a.transition_to(
+        SessionState.CONNECTED, reason="Unit Test", metadata=metadata
+    )
     manager_a.increment_message_count()
-    
+
     # Wait for background persistence
     await asyncio.sleep(0.5)
     print("✅ Instance A: State and Metadata persisted.")
@@ -31,7 +37,7 @@ async def verify_persistence():
     # 3. Instance B: Restore session
     manager_b = SessionStateManager(bus=bus)
     success = await manager_b.restore_from_bus("verify-sid-123")
-    
+
     if success:
         print(f"✅ Instance B: Restored session {manager_b.metadata.session_id}")
         assert manager_b.metadata.session_id == "verify-sid-123"
@@ -40,8 +46,9 @@ async def verify_persistence():
         print("🔥 Persistence verification SUCCESS.")
     else:
         print("❌ Instance B: Failed to restore session from bus.")
-        
+
     await bus.disconnect()
+
 
 if __name__ == "__main__":
     asyncio.run(verify_persistence())


### PR DESCRIPTION
This PR addresses a testing gap in the `InfraManager` class, specifically the untested `stop()` method that delegates to `SREWatchdog`. 

### Changes:
- Added `tests/unit/test_infra_manager.py` with comprehensive unit tests for `InfraManager`.
- The `stop()` method is now verified to correctly call the underlying watchdog's `stop()` method.
- Added tests for other critical `InfraManager` methods: `initialize()`, `start_watchdog()`, and `end_session()`.
- Implemented a robust mocking strategy to handle missing third-party dependencies (`firebase-admin`, `numpy`, etc.) in the test environment, ensuring tests can run reliably without external requirements.
- Fixed various linting and style issues across the `tests/` directory (unused imports, unsorted imports, f-string without placeholders, etc.) discovered during CI.

### Coverage:
- `InfraManager.initialize()`: Success and failure paths.
- `InfraManager.start_watchdog()`: Verification of watchdog start.
- `InfraManager.stop()`: Verification of watchdog stop.
- `InfraManager.end_session()`: Connected and disconnected states.

### Result:
Improved reliability and verification of the infrastructure management layer, providing a safety net for future refactoring of infrastructure components, and ensuring a clean CI state for the test suite.


---
*PR created automatically by Jules for task [4924859146272956362](https://jules.google.com/task/4924859146272956362) started by @Moeabdelaziz007*