### PR TITLE
🧹 Fix unused imports in dependency checker

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -19,6 +19,7 @@ ADK (Agent Development Kit) lifecycle patterns.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import os
 import sys
 from pathlib import Path
@@ -87,15 +88,15 @@ def check_dependencies() -> list[str]:
     """Check that critical dependencies are available."""
     missing = []
     try:
-        import pyaudio  # noqa: F401
+        importlib.import_module("pyaudio")
     except ImportError:
         missing.append("pyaudio")
     try:
-        from google import genai  # noqa: F401
+        importlib.import_module("google.genai")
     except ImportError:
         missing.append("google-genai")
     try:
-        from pydantic_settings import BaseSettings  # noqa: F401
+        importlib.import_module("pydantic_settings")
     except ImportError:
         missing.append("pydantic-settings")
     return missing
@@ -130,7 +131,8 @@ def main() -> None:
     try:
         engine = AetherEngine()
         print(
-            f"{CYAN}✦ Admin API Listening on http://localhost:18790/health (Tauri Bridge Active){RESET}"
+            f"{CYAN}✦ Admin API Listening on http://localhost:18790/health "
+            f"(Tauri Bridge Active){RESET}"
         )
         asyncio.run(engine.run())
     except KeyboardInterrupt:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was "Unused import" warnings in the `check_dependencies` function in `core/server.py`.
💡 **Why:** By replacing the `import` statements (which necessitated `# noqa: F401` overrides) with dynamic imports using `importlib.import_module()`, we cleanly solve the static analysis issue while retaining the exact functionality of validating dependency presence. It improves maintainability by removing lint suppression comments and clearly communicating the intent (dynamically loading a module to test its presence).
✅ **Verification:** Ran `ruff check` on the file to confirm lint errors (including a long line length error) are resolved, and executed the dependency checker locally by writing a small test script to ensure `ImportError`s are still raised appropriately.
✨ **Result:** The codebase no longer relies on `# noqa` suppressions for unused imports in `core/server.py`, resulting in cleaner, more readable code that seamlessly checks dependency availability.

---
*PR created automatically by Jules for task [16946745606571215547](https://jules.google.com/task/16946745606571215547) started by @Moeabdelaziz007*