### PR TITLE
🧪 [testing improvement agent-manager]

### DIFF
--- a/core/identity/package.py
+++ b/core/identity/package.py
@@ -94,11 +94,7 @@ class AthPackage:
         """
         manifest_path = package_dir / "manifest.json"
         if not manifest_path.exists():
-<<<<<<< HEAD
             raise ManifestValidationError(
-=======
-            raise ManifestValidationError
->>>>>>> origin/jules-3466090822907057400-4af64808
                 f"No manifest.json found in {package_dir}",
                 context={"path": str(package_dir)},
             )
@@ -107,11 +103,7 @@ class AthPackage:
             raw = manifest_path.read_text(encoding="utf-8")
             data = json.loads(raw)
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-<<<<<<< HEAD
             raise ManifestValidationError(
-=======
-            raise ManifestValidationError
->>>>>>> origin/jules-3466090822907057400-4af64808
                 f"Invalid manifest.json: {exc}",
                 cause=exc,
                 context={"path": str(manifest_path)},
@@ -120,11 +112,7 @@ class AthPackage:
         try:
             manifest = SoulManifest(**data)
         except Exception as exc:
-<<<<<<< HEAD
             raise ManifestValidationError(
-=======
-            raise ManifestValidationError
->>>>>>> origin/jules-3466090822907057400-4af64808
                 f"Manifest validation failed: {exc}",
                 cause=exc,
                 context={"path": str(manifest_path), "data": data},

--- a/core/infra/telemetry.py
+++ b/core/infra/telemetry.py
@@ -38,11 +38,7 @@ class TelemetryManager:
             return
 
         try:
-<<<<<<< HEAD
             resource = Resource(
-=======
-            resource = Resource
->>>>>>> origin/jules-3466090822907057400-4af64808
                 attributes={
                     "model_id": self.model_id,
                     "model_version": self.model_version,
@@ -64,11 +60,7 @@ class TelemetryManager:
                 else SimpleSpanProcessor
             )
 
-<<<<<<< HEAD
             exporter = OTLPSpanExporter(endpoint=self.endpoint, headers=headers)
-=======
-            exporter = Otlpspanexporterendpoint=self.endpoint, headers=headers)
->>>>>>> origin/jules-3466090822907057400-4af64808
 
             provider.add_span_processor(processor_class(exporter))
             trace_api.set_tracer_provider(provider)
@@ -121,11 +113,7 @@ class TelemetryManager:
 
 
 # Global Singleton
-<<<<<<< HEAD
 _manager = TelemetryManager()
-=======
-_manager = TelemetryManager)
->>>>>>> origin/jules-3466090822907057400-4af64808
 
 
 def get_tracer() -> trace_api.Tracer:

--- a/core/services/registry.py
+++ b/core/services/registry.py
@@ -21,7 +21,7 @@ from core.utils.errors import IdentityError, PackageNotFoundError
 logger = logging.getLogger(__name__)
 
 
-class PackageChangeHandler(FileSystemEventHandler)):
+class PackageChangeHandler(FileSystemEventHandler):
     """Handles filesystem events for the packages directory."""
 
     def __init__(self, registry: AetherRegistry) -> None:
@@ -32,13 +32,13 @@ class PackageChangeHandler(FileSystemEventHandler)):
             return
         if event.src_path.endswith("manifest.json"):
             # A package manifest changed, trigger reload
-            pkg_path = Pathevent.src_path).parent
+            pkg_path = Path(event.src_path).parent
             self._registry._handle_fs_change(pkg_path)
 
     def on_created(self, event: FileSystemEvent) -> None:
         if event.is_directory:
             # New directory might be a new package
-            self._registry._handle_fs_change(Pathevent.src_path))
+            self._registry._handle_fs_change(Path(event.src_path))
 
 
 class AetherRegistry:
@@ -54,7 +54,7 @@ class AetherRegistry:
         packages_dir: str,
         on_change: Optional[Callable[[str, Optional[AthPackage]], Any]] = None,
     ) -> None:
-        self._dir = Pathpackages_dir)
+        self._dir = Path(packages_dir)
         self._packages: dict[str, AthPackage] = {}
         self._discovered_paths: dict[str, Path] = {}  # Lazy-loading map
         self._on_change = on_change
@@ -114,7 +114,7 @@ class AetherRegistry:
         if self._observer:
             return
 
-        self._observer = Observer)
+        self._observer = Observer()
         self._observer.schedule(
             PackageChangeHandler(self), str(self._dir), recursive=True
         )
@@ -171,13 +171,13 @@ class AetherRegistry:
             if pkg:
                 return pkg
 
-        raise PackageNotFoundErrorf"Package '{name}' not found")
+        raise PackageNotFoundError(f"Package '{name}' not found")
 
     def initialize_vector_store(self, api_key: str) -> None:
         """Initialize the local vector store for semantic expert discovery."""
         from core.tools.vector_store import LocalVectorStore
 
-        self._vector_store = LocalVectorStoreapi_key=api_key)
+        self._vector_store = LocalVectorStore(api_key=api_key)
         # Re-index all existing packages
         for pkg in self._packages.values():
             self._index_package(pkg)

--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -90,3 +90,16 @@ def test_on_package_change_unload(agent_manager, caplog):
     asyncio.run(agent_manager._on_package_change("test_pkg", None))
 
     assert "Unloading package: test_pkg" in caplog.text
+
+
+def test_scan_registry(agent_manager):
+    agent_manager.scan_registry()
+
+    agent_manager._registry.scan.assert_called_once()
+    agent_manager._registry.start_watcher.assert_called_once()
+
+
+def test_stop_watcher(agent_manager):
+    agent_manager.stop_watcher()
+
+    agent_manager._registry.stop_watcher.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested `stop_watcher` delegation in the `AgentManager` class as well as the identically un-tested `scan_registry`. Both are methods simply delegating calls to a mockable `_registry`. 
  
  📊 **Coverage:** Tests now verify that invoking `scan_registry` calls the `_registry.scan` and `_registry.start_watcher` methods once. Tests also verify that calling `stop_watcher` invokes `_registry.stop_watcher` once. 
  
  ✨ **Result:** Test coverage improved and the build suite is green. Additionally, fixed several stray git conflict markers across various files that broke tests completely.

---
*PR created automatically by Jules for task [12058701580361539529](https://jules.google.com/task/12058701580361539529) started by @Moeabdelaziz007*