### PR TITLE
🧪 test: Improve coverage for AudioManager start/stop

### DIFF
--- a/core/audio/cortex/__init__.py
+++ b/core/audio/cortex/__init__.py
@@ -38,11 +38,7 @@ class CochlearBuffer:
         self.capacity = capacity
         self.use_rust = HAS_RUST_CORTEX
         if HAS_RUST_CORTEX:
-<<<<<<< HEAD
             self._rust_buf = RustCochlearBuffer(capacity)
-=======
-            self._rust_buf = RustCochlearBuffercapacity)
->>>>>>> origin/jules-3466090822907057400-4af64808
         else:
             # Fallback to simple numpy ring buffer
             self._buf = np.zeros(capacity, dtype=np.int16)

--- a/core/audio/dynamic_aec.py
+++ b/core/audio/dynamic_aec.py
@@ -273,11 +273,7 @@ class DoubleTalkDetector:
         self.energy_ratio_threshold = energy_ratio_threshold
         self.hangover_frames = hangover_frames
 
-<<<<<<< HEAD
         self.spectral_analyzer = SpectralAnalyzer(sample_rate=sample_rate)
-=======
-        self.spectral_analyzer = SpectralAnalyzersample_rate=sample_rate)
->>>>>>> origin/jules-3466090822907057400-4af64808
 
         # Ring buffers for history
         self.far_end_history: deque[np.ndarray] = deque(maxlen=4)
@@ -530,51 +526,35 @@ class DynamicAEC:
         filter_length = max(filter_length, 512)  # Minimum 512 samples
 
         # Initialize components
-<<<<<<< HEAD
         self.adaptive_filter = FrequencyDomainNLMS(
-=======
-        self.adaptive_filter = FrequencyDomainNLMS
->>>>>>> origin/jules-3466090822907057400-4af64808
             filter_length=filter_length,
             step_size=step_size,
             regularization=1e-4,
             leakage=0.999,
         )
 
-<<<<<<< HEAD
         self.delay_estimator = DelayEstimator(
-=======
-        self.delay_estimator = DelayEstimator
->>>>>>> origin/jules-3466090822907057400-4af64808
             sample_rate=sample_rate,
             max_delay_ms=200.0,
             update_interval_ms=500.0,
             smoothing_factor=0.9,
         )
 
-<<<<<<< HEAD
         self.double_talk_detector = DoubleTalkDetector(
-=======
-        self.double_talk_detector = DoubleTalkDetector
->>>>>>> origin/jules-3466090822907057400-4af64808
             sample_rate=sample_rate,
             coherence_threshold=0.65,
             energy_ratio_threshold=0.5,
             hangover_frames=10,
         )
 
-<<<<<<< HEAD
         self.spectral_analyzer = SpectralAnalyzer(sample_rate=sample_rate, n_fft=512)
-=======
-        self.spectral_analyzer = SpectralAnalyzersample_rate=sample_rate, n_fft=512)
->>>>>>> origin/jules-3466090822907057400-4af64808
+        self.spectral_analyzer = SpectralAnalyzer(sample_rate=sample_rate, n_fft=512)
 
         # Frame accumulation for block processing
         self.block_size = filter_length  # Process in filter-length blocks
 
         # Ring buffers for delay compensation
         self.far_end_ring_buffer: deque[np.ndarray] = deque(maxlen=20)
-<<<<<<< HEAD
         self.accumulated_far_end = BoundedBuffer(
             max_samples=sample_rate * 5
         )  # 5s limit
@@ -585,18 +565,7 @@ class DynamicAEC:
 
         # State
         self.state = AECState()
-=======
-        self.accumulated_far_end = BoundedBuffer
-            max_samples=sample_rate * 5
-        )  # 5s limit
 
-        self.near_end_accumulator = BoundedBuffermax_samples=self.block_size * 2)
-        self.far_end_accumulator = BoundedBuffermax_samples=self.block_size * 2)
-        self.accumulated_samples = 0
-
-        # State
-        self.state = AECState)
->>>>>>> origin/jules-3466090822907057400-4af64808
         self.erle_history: deque[float] = deque(maxlen=50)
 
         # Convergence tracking
@@ -837,11 +806,7 @@ class DynamicAEC:
 
             # Only recreate filter if length changed significantly
             if abs(new_filter_length - self.adaptive_filter.filter_length) > 64:
-<<<<<<< HEAD
                 self.adaptive_filter = FrequencyDomainNLMS(
-=======
-                self.adaptive_filter = FrequencyDomainNLMS
->>>>>>> origin/jules-3466090822907057400-4af64808
                     filter_length=new_filter_length,
                     step_size=self.adaptive_filter.step_size,
                     regularization=1e-4,
@@ -864,19 +829,11 @@ class DynamicAEC:
         self.double_talk_detector.reset()
         self.spectral_analyzer.reset()
         self.far_end_ring_buffer.clear()
-<<<<<<< HEAD
         self.accumulated_far_end = BoundedBuffer(max_samples=self.sample_rate * 5)
         self.near_end_accumulator = BoundedBuffer(max_samples=self.block_size * 2)
         self.far_end_accumulator = BoundedBuffer(max_samples=self.block_size * 2)
         self.accumulated_samples = 0
         self.state = AECState()
-=======
-        self.accumulated_far_end = BoundedBuffermax_samples=self.sample_rate * 5)
-        self.near_end_accumulator = BoundedBuffermax_samples=self.block_size * 2)
-        self.far_end_accumulator = BoundedBuffermax_samples=self.block_size * 2)
-        self.accumulated_samples = 0
-        self.state = AECState)
->>>>>>> origin/jules-3466090822907057400-4af64808
         self.erle_history.clear()
         self.convergence_frame_count = 0
         logger.info("DynamicAEC reset")

--- a/core/audio/playback.py
+++ b/core/audio/playback.py
@@ -105,11 +105,7 @@ class AudioPlayback:
         try:
             self._pya.get_default_output_device_info()
         except IOError as exc:
-<<<<<<< HEAD
             raise AudioDeviceNotFoundError(
-=======
-            raise Audiodevicenotfounderror
->>>>>>> origin/jules-3466090822907057400-4af64808
                 "No default output device found.",
                 cause=exc,
             ) from exc
@@ -136,11 +132,7 @@ class AudioPlayback:
         This provides backpressure to the AI session.
         """
         if not self._stream:
-<<<<<<< HEAD
             raise AudioDeviceNotFoundError("Call start() before run()")
-=======
-            raise Audiodevicenotfounderror"Call start() before run()")
->>>>>>> origin/jules-3466090822907057400-4af64808
 
         logger.info("Audio playback feeder running")
 

--- a/core/audio/processing.py
+++ b/core/audio/processing.py
@@ -423,11 +423,7 @@ def energy_vad(
             is_hard = energy_rms > threshold
             is_soft = is_hard  # No soft distinction without adaptive engine
 
-<<<<<<< HEAD
         return HyperVADResult(
-=======
-        return HyperVADResult
->>>>>>> origin/jules-3466090822907057400-4af64808
             is_soft=bool(is_soft),
             is_hard=bool(is_hard),
             energy_rms=energy_rms,
@@ -460,11 +456,7 @@ def enhanced_vad(
         A `HyperVADResult` object with the VAD decision and energy stats.
     """
     if len(pcm_chunk) == 0:
-<<<<<<< HEAD
         return HyperVADResult(
-=======
-        return HyperVADResult
->>>>>>> origin/jules-3466090822907057400-4af64808
             is_soft=False, is_hard=False, energy_rms=0.0, sample_count=0
         )
 
@@ -507,11 +499,7 @@ def enhanced_vad(
         is_hard = (rms > threshold) and (speech_score > 0.5)
         is_soft = is_hard
 
-<<<<<<< HEAD
     return HyperVADResult(
-=======
-    return HyperVADResult
->>>>>>> origin/jules-3466090822907057400-4af64808
         is_soft=bool(is_soft),
         is_hard=bool(is_hard),
         energy_rms=rms,

--- a/core/audio/state.py
+++ b/core/audio/state.py
@@ -70,11 +70,8 @@ class AudioState:
                 cls._instance.aec_delay_ms = 0.0  # Estimated echo delay
                 cls._instance.aec_double_talk = False  # Double-talk detection
                 # Reference buffer for loopback AEC (2 seconds @ 16kHz)
-<<<<<<< HEAD
                 cls._instance.far_end_pcm = RingBuffer(32000)
-=======
-                cls._instance.far_end_pcm = Ringbuffer32000)
->>>>>>> origin/jules-3466090822907057400-4af64808
+                cls._instance.far_end_pcm = RingBuffer(32000)
         return cls._instance
 
     def update_aec_state(
@@ -129,8 +126,5 @@ class AudioState:
 
 
 # Global singleton
-<<<<<<< HEAD
 audio_state = AudioState()
-=======
-audio_state = AudioState)
->>>>>>> origin/jules-3466090822907057400-4af64808
+audio_state = AudioState()

--- a/core/logic/managers/audio.py
+++ b/core/logic/managers/audio.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 try:
     import ujson as json

--- a/tests/unit/test_audio_manager.py
+++ b/tests/unit/test_audio_manager.py
@@ -1,0 +1,73 @@
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+def setup_mocks():
+    mock_modules = ['firebase_admin', 'firebase_admin.credentials', 'firebase_admin.firestore', 'google.cloud.firestore', 'websockets', 'google.genai', 'pyaudio', 'watchdog', 'watchdog.observers', 'watchdog.events', 'webrtcvad']
+    for module_name in mock_modules:
+        if module_name not in sys.modules:
+            sys.modules[module_name] = MagicMock()
+
+setup_mocks()
+
+import pytest  # noqa: E402
+
+from core.logic.managers.audio import AudioManager  # noqa: E402
+from core.infra.config import AetherConfig  # noqa: E402
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock(spec=AetherConfig)
+    config.audio = MagicMock()
+    config.audio.send_sample_rate = 16000
+    config.audio.vad_window_sec = 5.0
+    return config
+
+
+@pytest.fixture
+def mock_gateway():
+    gateway = MagicMock()
+    gateway.audio_in_queue = MagicMock()
+    gateway.audio_out_queue = MagicMock()
+    gateway.broadcast = MagicMock()
+    gateway.broadcast_binary = MagicMock()
+    return gateway
+
+
+@pytest.fixture
+def audio_manager(mock_config, mock_gateway):
+    with (
+        patch("core.logic.managers.audio.ParalinguisticAnalyzer"),
+        patch("core.logic.managers.audio.AdaptiveVAD"),
+        patch("core.logic.managers.audio.AudioCapture"),
+        patch("core.logic.managers.audio.AudioPlayback")
+    ):
+        manager = AudioManager(
+            config=mock_config,
+            gateway=mock_gateway,
+            on_affective_data=MagicMock()
+        )
+        return manager
+
+
+def test_audio_manager_start(audio_manager):
+    # Setup the async mocks for start methods
+    audio_manager._capture.start = AsyncMock()
+    audio_manager._playback.start = AsyncMock()
+
+    # Call the method
+    asyncio.run(audio_manager.start())
+
+    # Verify both were called
+    audio_manager._capture.start.assert_called_once()
+    audio_manager._playback.start.assert_called_once()
+
+def test_audio_manager_stop(audio_manager):
+    audio_manager._capture.stop = AsyncMock()
+    audio_manager._playback.stop = AsyncMock()
+
+    asyncio.run(audio_manager.stop())
+
+    audio_manager._capture.stop.assert_called_once()
+    audio_manager._playback.stop.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The `AudioManager.start()` and `.stop()` methods were untested and caused gaps in coverage. In addition, the `core/audio` sub-module had several files that failed to import due to un-resolved `<<<<<<< HEAD` merge conflict markers in a previous change.

📊 **Coverage:** The tests now mock the internal async dependencies (`AudioCapture`, `AudioPlayback`) and ensure that calling `start()` and `stop()` correctly starts and stops the capture and playback services, respectively. 

✨ **Result:** Both the underlying syntax errors from conflict markers and the coverage gap have been fixed. tests are passing locally and ready for review.

---
*PR created automatically by Jules for task [2614365890144276001](https://jules.google.com/task/2614365890144276001) started by @Moeabdelaziz007*